### PR TITLE
docs: add note about Aztec version installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@
 
 1. Install Aztec by following the instructions from [their documentation](https://docs.aztec.network/developers/getting_started).
 2. Install the dependencies by running: `yarn install`
+
+> **Note:** Ensure you use the Aztec version specified in package.json. To install the correct version, run:
+> 
+> `VERSION=${version} aztec-up`
+
 3. Ensure you have Docker installed and running (required for Aztec sandbox)
 
 ## Build


### PR DESCRIPTION
This pull request updates the README to include a note that emphasizes the importance of using the Aztec version specified in package.json. It instructs users to install the correct version using the command:

    VERSION=${version} aztec-up

This change ensures that users use the appropriate Aztec version as per the project requirements. Please review and merge if everything looks good.