### PR TITLE
ci: updates versions, starts caching aztec image, node modules, artifacts and more

### DIFF
--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -18,13 +18,16 @@ jobs:
       # ──────────────────────────────────────────────────────────────
       # 0️⃣  SHARED TOOLING – Buildx + Aztec CLI skeleton
       # ──────────────────────────────────────────────────────────────
-      - name: Checkout repo (full history)
-        uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Buildx (Aztec sandbox needs BuildKit)
-        uses: docker/setup-buildx-action@v2
+      - name: Install and cache yarn
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
 
       - name: Install Aztec CLI
         run: |
@@ -87,7 +90,7 @@ jobs:
       # clean does not work correctly and is removing the benchmark results anyways
       # https://github.com/actions/checkout/issues/1201
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           clean: false

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -41,7 +41,7 @@ jobs:
       # 1️⃣  BENCHMARK BASE COMMIT
       # ──────────────────────────────────────────────────────────────
       - name: Checkout BASE branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
@@ -64,9 +64,17 @@ jobs:
           VERSION=${{ steps.basever.outputs.ver }} aztec \
             start --port 8081 --pxe --pxe.nodeUrl=http://localhost:8080/ \
             --pxe.proverEnabled false &
+      
+      - name: Cache node_modules (BASE)
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
 
       - name: Install deps (BASE)
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Compile contracts (BASE)
         run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"
@@ -133,9 +141,17 @@ jobs:
           VERSION=${{ steps.prver.outputs.ver }} aztec \
             start --port 8081 --pxe --pxe.nodeUrl=http://localhost:8080/ \
             --pxe.proverEnabled false &
+      
+      - name: Cache node_modules (PR)
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
 
       - name: Install deps (PR)
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Compile contracts (PR)
         run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -27,12 +27,12 @@ jobs:
         run: |
           echo "Checking for changes that would affect benchmarks..."
           
-          # Check if Noir contracts or config changed
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^(src/nr/|Nargo\.toml)'; then
-            echo "📝 Noir contract or config files changed"
+          # Check if Noir contracts, config, or benchmarks changed
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^(src/nr/|Nargo\.toml|benchmarks/)'; then
+            echo "📝 Noir contracts, config, or benchmark files changed"
             echo "should-benchmark=true" >> $GITHUB_OUTPUT
           else
-            echo "📁 No Noir contract or config changes detected"
+            echo "📁 No Noir contract, config, or benchmark changes detected"
             
             # Check for AZTEC_VERSION change in package.json
             if git diff ${{ github.event.pull_request.base.sha }} HEAD package.json | grep -q 'aztecVersion'; then

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -11,7 +11,63 @@ env:
   BENCH_DIR: ./benchmarks
 
 jobs:
+  check-changes:
+    name: Check for benchmark-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should-benchmark: ${{ steps.changes.outputs.should-benchmark }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for relevant changes
+        id: changes
+        run: |
+          echo "Checking for changes that would affect benchmarks..."
+          
+          # Check if Noir contracts or config changed
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^(src/nr/|Nargo\.toml)'; then
+            echo "📝 Noir contract or config files changed"
+            echo "should-benchmark=true" >> $GITHUB_OUTPUT
+          else
+            echo "📁 No Noir contract or config changes detected"
+            
+            # Check for AZTEC_VERSION change in package.json
+            if git diff ${{ github.event.pull_request.base.sha }} HEAD package.json | grep -q 'aztecVersion'; then
+              echo "🔄 AZTEC_VERSION changed in package.json"
+              echo "should-benchmark=true" >> $GITHUB_OUTPUT
+            else
+              echo "⏭️ No benchmark-relevant changes detected, skipping benchmarks"
+              echo "should-benchmark=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  benchmark-skipped:
+    name: Skip benchmarks
+    needs: check-changes
+    if: needs.check-changes.outputs.should-benchmark == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## 🤖 Benchmarks Skipped
+            
+            No benchmark-relevant changes detected in this PR.
+            
+            **Benchmarks only run when these files change:**
+            - `src/nr/**/*` (Noir contract files)
+            - `Nargo.toml` (Noir configuration)
+            - `aztecVersion` in `package.json`
+
   benchmark:
+    name: Run benchmark comparison
+    needs: check-changes
+    if: needs.check-changes.outputs.should-benchmark == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -76,10 +76,24 @@ jobs:
       - name: Install deps (BASE)
         run: yarn install --frozen-lockfile
 
+      - name: Cache Noir compilation artifacts (BASE)
+        id: cache-noir-base
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/
+            src/artifacts/
+          key: ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-noir-
+            ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-
+
       - name: Compile contracts (BASE)
+        if: steps.cache-noir-base.outputs.cache-hit != 'true'
         run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"
 
       - name: Codegen wrappers (BASE)
+        if: steps.cache-noir-base.outputs.cache-hit != 'true'
         run: script -e -c "aztec codegen target --outdir src/artifacts --force"
 
       - name: Benchmark (BASE)
@@ -153,10 +167,24 @@ jobs:
       - name: Install deps (PR)
         run: yarn install --frozen-lockfile
 
+      - name: Cache Noir compilation artifacts (PR)
+        id: cache-noir-pr
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/
+            src/artifacts/
+          key: ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-noir-
+            ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-
+
       - name: Compile contracts (PR)
+        if: steps.cache-noir-pr.outputs.cache-hit != 'true'
         run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"
 
       - name: Codegen wrappers (PR)
+        if: steps.cache-noir-pr.outputs.cache-hit != 'true'
         run: script -e -c "aztec codegen target --outdir src/artifacts --force"
 
       # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -44,26 +44,6 @@ jobs:
             fi
           fi
 
-  benchmark-skipped:
-    name: Skip benchmarks
-    needs: check-changes
-    if: needs.check-changes.outputs.should-benchmark == 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## 🤖 Benchmarks Skipped
-            
-            No benchmark-relevant changes detected in this PR.
-            
-            **Benchmarks only run when these files change:**
-            - `src/nr/**/*` (Noir contract files)
-            - `Nargo.toml` (Noir configuration)
-            - `aztecVersion` in `package.json`
-
   benchmark:
     name: Run benchmark comparison
     needs: check-changes

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -84,9 +84,6 @@ jobs:
             target/
             src/artifacts/
           key: ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-noir-
-            ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-
 
       - name: Compile contracts (BASE)
         if: steps.cache-noir-base.outputs.cache-hit != 'true'
@@ -175,9 +172,6 @@ jobs:
             target/
             src/artifacts/
           key: ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-noir-
-            ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-
 
       - name: Compile contracts (PR)
         if: steps.cache-noir-pr.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Start PXE
         run: |
-          VERSION=$AZTEC_VERSION aztec start --port 8081 --pxe --pxe.nodeUrl=http://localhost:8080/ --pxe.proverEnabled false &
+          aztec start --port 8081 --pxe --pxe.nodeUrl=http://localhost:8080/ --pxe.proverEnabled false &
 
       - name: Run nr tests
         run: script -e -c "aztec test"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,106 +7,68 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-    setup-and-run:
-      name: Setup and run tests
-      runs-on: ubuntu-latest
-      timeout-minutes: 60
+  setup-and-run:
+    name: Setup and run tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
 
-      env:
-        AZTEC_VERSION: 0.87.2
+    env:
+      AZTEC_VERSION: 0.87.2
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-          with:
-            fetch-depth: 0 # Fetch all history for comparison
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for comparison
 
-        - name: Install and cache yarn
-          uses: actions/setup-node@v4
-          with:
-            node-version: '20'
-            cache: 'yarn'
-            cache-dependency-path: 'yarn.lock'
+      - name: Install and cache project dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
 
-        - name: Set up Docker
-          uses: docker/setup-buildx-action@v3
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3    
 
-        - name: Cache Docker images
-          id: cache-docker
-          uses: actions/cache@v4
-          with:
-            path: /tmp/docker-aztec-images
-            key: ${{ runner.os }}-docker-aztec-${{ env.AZTEC_VERSION }}
-            restore-keys: |
-              ${{ runner.os }}-docker-aztec-
+      - name: Cache Noir compilation artifacts
+        id: cache-noir
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/
+            src/artifacts/
+          key: ${{ runner.os }}-noir-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-noir-
 
-        - name: Load cached Docker images
-          if: steps.cache-docker.outputs.cache-hit == 'true'
-          run: |
-            if [ -d /tmp/docker-aztec-images ]; then
-              for image in /tmp/docker-aztec-images/*.tar; do
-                [ -f "$image" ] && docker load < "$image" || true
-              done
-            fi
+      - name: Install Aztec CLI
+        run: |
+          curl -s https://install.aztec.network > tmp.sh
+          bash tmp.sh <<< yes "yes"
 
-        - name: Cache Noir compilation artifacts
-          id: cache-noir
-          uses: actions/cache@v4
-          with:
-            path: |
-              target/
-              src/artifacts/
-            key: ${{ runner.os }}-noir-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
-            restore-keys: |
-              ${{ runner.os }}-noir-
+      - name: Update path
+        run: echo "/home/runner/.aztec/bin" >> $GITHUB_PATH
 
-        - name: Install Aztec CLI
-          run: |
-            curl -s https://install.aztec.network > tmp.sh
-            bash tmp.sh <<< yes "yes"
+      - name: Set Aztec version
+        run: VERSION=$AZTEC_VERSION aztec-up
 
-        - name: Update path
-          run: echo "/home/runner/.aztec/bin" >> $GITHUB_PATH
+      - name: Start sandbox
+        run: aztec start --sandbox &
 
-        - name: Set Aztec version
-          run: |
-            VERSION=$AZTEC_VERSION aztec-up
+      - name: Compile contracts
+        if: steps.cache-noir.outputs.cache-hit != 'true'
+        run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"
 
-        - name: Save Docker images to cache
-          if: steps.cache-docker.outputs.cache-hit != 'true'
-          run: |
-            mkdir -p /tmp/docker-aztec-images
-            # Get all aztecprotocol images with current version
-            docker images aztecprotocol/* --format "{{.Repository}}:{{.Tag}}" | \
-            grep ":${{ env.AZTEC_VERSION }}" | \
-            while read image; do
-              echo "Saving $image..."
-              filename=$(echo "$image" | sed 's/[\/:]/-/g')
-              docker save "$image" > "/tmp/docker-aztec-images/${filename}.tar"
-            done
+      - name: Generate artifacts
+        if: steps.cache-noir.outputs.cache-hit != 'true'
+        run: script -e -c "aztec codegen target --outdir src/artifacts"
 
-        - name: Start sandbox
-          run: |
-            aztec start --sandbox &
+      - name: Start PXE
+        run: |
+          VERSION=$AZTEC_VERSION aztec start --port 8081 --pxe --pxe.nodeUrl=http://localhost:8080/ --pxe.proverEnabled false &
 
-        - name: Install project dependencies
-          run: yarn
+      - name: Run nr tests
+        run: script -e -c "aztec test"
 
-        - name: Compile contracts
-          if: steps.cache-noir.outputs.cache-hit != 'true'
-          run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"
-
-        - name: Generate artifacts
-          if: steps.cache-noir.outputs.cache-hit != 'true'
-          run: script -e -c "aztec codegen target --outdir src/artifacts"
-
-        - name: Start PXE
-          run: |
-            VERSION=$AZTEC_VERSION aztec start --port 8081 --pxe --pxe.nodeUrl=http://localhost:8080/ --pxe.proverEnabled false &
-
-        - name: Run nr tests
-          run: |
-            script -e -c "aztec test"
-
-        - name: Run js tests
-          run: script -e -c "BASE_PXE_URL=http://localhost NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json"
+      - name: Run js tests
+        run: script -e -c "BASE_PXE_URL=http://localhost NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,20 +17,48 @@ jobs:
 
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             fetch-depth: 0 # Fetch all history for comparison
 
-        - name: Set up Docker
-          uses: docker/setup-buildx-action@v2
-
-        - name: Check for changes in src/
-          uses: dorny/paths-filter@v3
-          id: changes
+        - name: Install and cache yarn
+          uses: actions/setup-node@v4
           with:
-            filters: |
-              src:
-                - 'src/**'
+            node-version: '20'
+            cache: 'yarn'
+            cache-dependency-path: 'yarn.lock'
+
+        - name: Set up Docker
+          uses: docker/setup-buildx-action@v3
+
+        - name: Cache Docker images
+          id: cache-docker
+          uses: actions/cache@v4
+          with:
+            path: /tmp/docker-aztec-images
+            key: ${{ runner.os }}-docker-aztec-${{ env.AZTEC_VERSION }}
+            restore-keys: |
+              ${{ runner.os }}-docker-aztec-
+
+        - name: Load cached Docker images
+          if: steps.cache-docker.outputs.cache-hit == 'true'
+          run: |
+            if [ -d /tmp/docker-aztec-images ]; then
+              for image in /tmp/docker-aztec-images/*.tar; do
+                [ -f "$image" ] && docker load < "$image" || true
+              done
+            fi
+
+        - name: Cache Noir compilation artifacts
+          id: cache-noir
+          uses: actions/cache@v4
+          with:
+            path: |
+              target/
+              src/artifacts/
+            key: ${{ runner.os }}-noir-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
+            restore-keys: |
+              ${{ runner.os }}-noir-
 
         - name: Install Aztec CLI
           run: |
@@ -44,6 +72,19 @@ jobs:
           run: |
             VERSION=$AZTEC_VERSION aztec-up
 
+        - name: Save Docker images to cache
+          if: steps.cache-docker.outputs.cache-hit != 'true'
+          run: |
+            mkdir -p /tmp/docker-aztec-images
+            # Get all aztecprotocol images with current version
+            docker images aztecprotocol/* --format "{{.Repository}}:{{.Tag}}" | \
+            grep ":${{ env.AZTEC_VERSION }}" | \
+            while read image; do
+              echo "Saving $image..."
+              filename=$(echo "$image" | sed 's/[\/:]/-/g')
+              docker save "$image" > "/tmp/docker-aztec-images/${filename}.tar"
+            done
+
         - name: Start sandbox
           run: |
             aztec start --sandbox &
@@ -51,10 +92,12 @@ jobs:
         - name: Install project dependencies
           run: yarn
 
-        - name: Compile
+        - name: Compile contracts
+          if: steps.cache-noir.outputs.cache-hit != 'true'
           run: script -e -c "${AZTEC_NARGO:-aztec-nargo} compile"
 
-        - name: Codegen
+        - name: Generate artifacts
+          if: steps.cache-noir.outputs.cache-hit != 'true'
           run: script -e -c "aztec codegen target --outdir src/artifacts"
 
         - name: Start PXE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,10 @@ jobs:
           path: |
             target/
             src/artifacts/
-          key: ${{ runner.os }}-noir-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
+          key: ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-noir-
+            ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-
 
       - name: Compile contracts
         if: steps.cache-noir.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,9 +60,6 @@ jobs:
             target/
             src/artifacts/
           key: ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-noir-
-            ${{ runner.os }}-noir-${{ env.AZTEC_VERSION }}-
 
       - name: Compile contracts
         if: steps.cache-noir.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,16 +19,38 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for comparison
+          fetch-depth: 0
 
-      - name: Install and cache project dependencies
+      - name: Install and cache yarn
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'yarn'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3    
+
+      - name: Install Aztec CLI
+        run: |
+          curl -s https://install.aztec.network > tmp.sh
+          VERSION=$AZTEC_VERSION bash tmp.sh <<< yes "yes"
+
+      - name: Update path
+        run: echo "/home/runner/.aztec/bin" >> $GITHUB_PATH
+
+      - name: Start sandbox
+        run: aztec start --sandbox &
 
       - name: Cache Noir compilation artifacts
         id: cache-noir
@@ -40,20 +62,6 @@ jobs:
           key: ${{ runner.os }}-noir-${{ hashFiles('src/nr/**/*', 'Nargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-noir-
-
-      - name: Install Aztec CLI
-        run: |
-          curl -s https://install.aztec.network > tmp.sh
-          bash tmp.sh <<< yes "yes"
-
-      - name: Update path
-        run: echo "/home/runner/.aztec/bin" >> $GITHUB_PATH
-
-      - name: Set Aztec version
-        run: VERSION=$AZTEC_VERSION aztec-up
-
-      - name: Start sandbox
-        run: aztec start --sandbox &
 
       - name: Compile contracts
         if: steps.cache-noir.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR aims to:
- Update all jobs versions to their latest
- Cache everywhere it makes sense (yarn global, node_modules, noir compilations and artifacts)
- We remove the double-installation of aztec images which took a lot of time: cli and set-up aztec version. We can directly install cli with the aztec version and save ~30s on tests. 

I think the only highly opinionated thing is that I've made the compare-benchmark skip the job if no noir files, nargo config or aztec version changed. LMK if you disagree and I'll roll it back.
