### PR TITLE
ci: fix commenting on prs from forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,12 +1,8 @@
-name: Aztec Benchmark Diff
+name: Aztec Benchmark
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-
-permissions:
-  contents: read
-  pull-requests: write
 
 env:
   BENCH_DIR: ./benchmarks
@@ -232,40 +228,33 @@ jobs:
         run: script -e -c "aztec codegen target --outdir src/artifacts --force"
 
       # ──────────────────────────────────────────────────────────────
-      # 3️⃣  DIFF &  COMMENT
+      # 3️⃣  DIFF &  UPLOAD ARTIFACTS
       # ──────────────────────────────────────────────────────────────
       - name: Generate Markdown diff
+        run: npx aztec-benchmark --suffix _pr --output-dir ${{ env.BENCH_DIR }}
+
+      - name: Generate benchmark comparison
         uses: defi-wonderland/aztec-benchmark/action@main
         with:
           base_suffix: '_base'
           current_suffix: '_pr'
 
-      # Upload benchmark results as artifact for secure comment job
-      - name: Upload benchmark results
+      # SECURITY: Upload results for secure comment workflow
+      - name: Upload benchmark results and metadata
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-comparison
-          path: benchmark-comparison.md
+          name: benchmark-results
+          path: |
+            benchmark-comparison.md
           retention-days: 1
 
-  # Secure job for commenting - no code checkout, only artifact download
-  comment-results:
-    name: Comment benchmark results on PR
-    needs: [check-changes, benchmark]
-    if: needs.check-changes.outputs.should-benchmark == 'true' && needs.benchmark.result == 'success'
-    runs-on: ubuntu-latest
-    
-    steps:
-      # SECURITY: Do NOT checkout PR code in this job
-      # This job has elevated permissions to comment but never touches untrusted code
-      
-      - name: Download benchmark results
-        uses: actions/download-artifact@v4
+      - name: Save PR number for comment workflow
+        run: |
+          echo "${{ github.event.number }}" > pr-number.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
         with:
-          name: benchmark-comparison
-          
-      - name: Comment benchmark diff on PR
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-file: benchmark-comparison.md
+          name: pr-metadata
+          path: pr-number.txt
+          retention-days: 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,19 +1,15 @@
-name: Aztec Benchmark Diff
+name: Aztec Benchmark
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-
-permissions:
-  contents: read
-  pull-requests: write
 
 env:
   BENCH_DIR: ./benchmarks
 
 jobs:
   check-changes:
-    name: Check for benchmark-relevant changes
+    name: Check for relevant changes
     runs-on: ubuntu-latest
     outputs:
       should-benchmark: ${{ steps.changes.outputs.should-benchmark }}
@@ -59,7 +55,7 @@ jobs:
             core.setOutput('should-benchmark', shouldBenchmark);
 
   benchmark:
-    name: Run benchmark comparison
+    name: Run comparison
     needs: check-changes
     if: needs.check-changes.outputs.should-benchmark == 'true'
     runs-on: ubuntu-latest
@@ -232,40 +228,33 @@ jobs:
         run: script -e -c "aztec codegen target --outdir src/artifacts --force"
 
       # ──────────────────────────────────────────────────────────────
-      # 3️⃣  DIFF &  COMMENT
+      # 3️⃣  DIFF &  UPLOAD ARTIFACTS
       # ──────────────────────────────────────────────────────────────
       - name: Generate Markdown diff
+        run: npx aztec-benchmark --suffix _pr --output-dir ${{ env.BENCH_DIR }}
+
+      - name: Generate benchmark comparison
         uses: defi-wonderland/aztec-benchmark/action@main
         with:
           base_suffix: '_base'
           current_suffix: '_pr'
 
-      # Upload benchmark results as artifact for secure comment job
-      - name: Upload benchmark results
+      # SECURITY: Upload results for secure comment workflow
+      - name: Upload benchmark results and metadata
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-comparison
-          path: benchmark-comparison.md
+          name: benchmark-results
+          path: |
+            benchmark-comparison.md
           retention-days: 1
 
-  # Secure job for commenting - no code checkout, only artifact download
-  comment-results:
-    name: Comment benchmark results on PR
-    needs: [check-changes, benchmark]
-    if: needs.check-changes.outputs.should-benchmark == 'true' && needs.benchmark.result == 'success'
-    runs-on: ubuntu-latest
-    
-    steps:
-      # SECURITY: Do NOT checkout PR code in this job
-      # This job has elevated permissions to comment but never touches untrusted code
-      
-      - name: Download benchmark results
-        uses: actions/download-artifact@v4
+      - name: Save PR number for comment workflow
+        run: |
+          echo "${{ github.event.number }}" > pr-number.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
         with:
-          name: benchmark-comparison
-          
-      - name: Comment benchmark diff on PR
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-file: benchmark-comparison.md
+          name: pr-metadata
+          path: pr-number.txt
+          retention-days: 1

--- a/.github/workflows/comment-benchmark.yml
+++ b/.github/workflows/comment-benchmark.yml
@@ -1,0 +1,115 @@
+name: Comment Results
+
+# SECURITY: workflow_run trigger = elevated permissions, no fork code access
+on:
+  workflow_run:
+    workflows: ["Aztec Benchmark"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write  # Elevated permissions for commenting
+
+jobs:
+  comment:
+    name: Comment results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    
+    steps:
+      # SECURITY: Never checkout PR code in this workflow
+      # This job has elevated permissions but only handles trusted artifacts
+      
+      - name: Download benchmark results
+        id: download-results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Download benchmark results artifact
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            
+            const benchmarkArtifact = artifacts.data.artifacts.find(artifact => 
+              artifact.name === 'benchmark-results'
+            );
+            
+            if (benchmarkArtifact) {
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: benchmarkArtifact.id,
+                archive_format: 'zip',
+              });
+              
+              const fs = require('fs');
+              fs.writeFileSync('benchmark-results.zip', Buffer.from(download.data));
+              console.log('Downloaded benchmark results artifact');
+            } else {
+              console.log('No benchmark results found - likely skipped due to no relevant changes');
+              core.setOutput('has-results', 'false');
+              return;
+            }
+            
+            core.setOutput('has-results', 'true');
+
+      - name: Extract benchmark results
+        if: steps.download-results.outputs.has-results == 'true'
+        id: extract-results
+        run: |
+          unzip -q benchmark-results.zip
+          if [[ -f benchmark-comparison.md ]]; then
+            echo "results-available=true" >> $GITHUB_OUTPUT
+            echo "Found benchmark comparison results"
+          else
+            echo "results-available=false" >> $GITHUB_OUTPUT
+            echo "No benchmark comparison file found"
+          fi
+
+      - name: Download PR metadata
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Download PR metadata artifact
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            
+            const metadataArtifact = artifacts.data.artifacts.find(artifact => 
+              artifact.name === 'pr-metadata'
+            );
+            
+            if (metadataArtifact) {
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: metadataArtifact.id,
+                archive_format: 'zip',
+              });
+              
+              const fs = require('fs');
+              fs.writeFileSync('pr-metadata.zip', Buffer.from(download.data));
+              console.log('Downloaded PR metadata artifact');
+            } else {
+              throw new Error('PR metadata artifact not found');
+            }
+
+      - name: Extract PR number
+        id: extract-pr
+        run: |
+          unzip -q pr-metadata.zip
+          PR_NUMBER=$(cat pr-number.txt)
+          echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Found PR number: $PR_NUMBER"
+
+      - name: Comment results
+        if: steps.extract-results.outputs.results-available == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.extract-pr.outputs.pr-number }}
+          body-file: benchmark-comparison.md

--- a/.github/workflows/comment-benchmark.yml
+++ b/.github/workflows/comment-benchmark.yml
@@ -1,0 +1,115 @@
+name: Comment Benchmark Results
+
+# SECURITY: workflow_run trigger = elevated permissions, no fork code access
+on:
+  workflow_run:
+    workflows: ["Aztec Benchmark"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write  # Elevated permissions for commenting
+
+jobs:
+  comment:
+    name: Comment benchmark results on PR
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    
+    steps:
+      # SECURITY: Never checkout PR code in this workflow
+      # This job has elevated permissions but only handles trusted artifacts
+      
+      - name: Download benchmark results
+        id: download-results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Download benchmark results artifact
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            
+            const benchmarkArtifact = artifacts.data.artifacts.find(artifact => 
+              artifact.name === 'benchmark-results'
+            );
+            
+            if (benchmarkArtifact) {
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: benchmarkArtifact.id,
+                archive_format: 'zip',
+              });
+              
+              const fs = require('fs');
+              fs.writeFileSync('benchmark-results.zip', Buffer.from(download.data));
+              console.log('Downloaded benchmark results artifact');
+            } else {
+              console.log('No benchmark results found - likely skipped due to no relevant changes');
+              core.setOutput('has-results', 'false');
+              return;
+            }
+            
+            core.setOutput('has-results', 'true');
+
+      - name: Extract benchmark results
+        if: steps.download-results.outputs.has-results == 'true'
+        id: extract-results
+        run: |
+          unzip -q benchmark-results.zip
+          if [[ -f benchmark-comparison.md ]]; then
+            echo "results-available=true" >> $GITHUB_OUTPUT
+            echo "Found benchmark comparison results"
+          else
+            echo "results-available=false" >> $GITHUB_OUTPUT
+            echo "No benchmark comparison file found"
+          fi
+
+      - name: Download PR metadata
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Download PR metadata artifact
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            
+            const metadataArtifact = artifacts.data.artifacts.find(artifact => 
+              artifact.name === 'pr-metadata'
+            );
+            
+            if (metadataArtifact) {
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: metadataArtifact.id,
+                archive_format: 'zip',
+              });
+              
+              const fs = require('fs');
+              fs.writeFileSync('pr-metadata.zip', Buffer.from(download.data));
+              console.log('Downloaded PR metadata artifact');
+            } else {
+              throw new Error('PR metadata artifact not found');
+            }
+
+      - name: Extract PR number
+        id: extract-pr
+        run: |
+          unzip -q pr-metadata.zip
+          PR_NUMBER=$(cat pr-number.txt)
+          echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Found PR number: $PR_NUMBER"
+
+      - name: Comment benchmark results on PR
+        if: steps.extract-results.outputs.results-available == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.extract-pr.outputs.pr-number }}
+          body-file: benchmark-comparison.md

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -12,43 +12,56 @@ env:
   BENCH_DIR: ./benchmarks
 
 jobs:
-  # check-changes:
-  #   name: Check for benchmark-relevant changes
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     should-benchmark: ${{ steps.changes.outputs.should-benchmark }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+  check-changes:
+    name: Check for benchmark-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should-benchmark: ${{ steps.changes.outputs.should-benchmark }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  #     - name: Check for relevant changes
-  #       id: changes
-  #       run: |
-  #         echo "Checking for changes that would affect benchmarks..."
-          
-  #         # Check if Noir contracts, config, or benchmarks changed
-  #         if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^(src/nr/|Nargo\.toml|benchmarks/)'; then
-  #           echo "📝 Noir contracts, config, or benchmark files changed"
-  #           echo "should-benchmark=true" >> $GITHUB_OUTPUT
-  #         else
-  #           echo "📁 No Noir contract, config, or benchmark changes detected"
+      - name: Check for relevant changes
+        id: changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Checking for changes that would affect benchmarks...');
             
-  #           # Check for AZTEC_VERSION change in package.json
-  #           if git diff ${{ github.event.pull_request.base.sha }} HEAD package.json | grep -q 'aztecVersion'; then
-  #             echo "🔄 AZTEC_VERSION changed in package.json"
-  #             echo "should-benchmark=true" >> $GITHUB_OUTPUT
-  #           else
-  #             echo "⏭️ No benchmark-relevant changes detected, skipping benchmarks"
-  #             echo "should-benchmark=false" >> $GITHUB_OUTPUT
-  #           fi
-  #         fi
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            
+            console.log('Changed files:');
+            files.forEach(file => console.log(`- ${file.filename}`));
+            
+            // Check for Noir contracts, config, or benchmark changes
+            const relevantPatterns = /^(src\/nr\/|Nargo\.toml|benchmarks\/)/;
+            const hasRelevantChanges = files.some(file => relevantPatterns.test(file.filename));
+            
+            // Check for AZTEC_VERSION change in package.json
+            const hasAztecVersionChange = files.some(file => 
+              file.filename === 'package.json' && file.patch?.includes('aztecVersion')
+            );
+            
+            const shouldBenchmark = hasRelevantChanges || hasAztecVersionChange;
+            
+            if (hasRelevantChanges) {
+              console.log('📝 Noir contracts, config, or benchmark files changed');
+            } else if (hasAztecVersionChange) {
+              console.log('🔄 AZTEC_VERSION changed in package.json');
+            } else {
+              console.log('⏭️ No benchmark-relevant changes detected, skipping benchmarks');
+            }
+            
+            core.setOutput('should-benchmark', shouldBenchmark);
 
   benchmark:
     name: Run benchmark comparison
-    # needs: check-changes
-    # if: needs.check-changes.outputs.should-benchmark == 'true'
+    needs: check-changes
+    if: needs.check-changes.outputs.should-benchmark == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -238,10 +251,8 @@ jobs:
   # Secure job for commenting - no code checkout, only artifact download
   comment-results:
     name: Comment benchmark results on PR
-    needs: [benchmark]
-    # needs: [check-changes, benchmark]
-    # if: needs.check-changes.outputs.should-benchmark == 'true' && needs.benchmark.result == 'success'
-    if: needs.benchmark.result == 'success'
+    needs: [check-changes, benchmark]
+    if: needs.check-changes.outputs.should-benchmark == 'true' && needs.benchmark.result == 'success'
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -1,7 +1,8 @@
 name: Aztec Benchmark Diff
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -47,7 +48,7 @@ jobs:
   benchmark:
     name: Run benchmark comparison
     needs: check-changes
-    if: needs.check-changes.outputs.should-benchmark == 'true'
+    # if: needs.check-changes.outputs.should-benchmark == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -226,7 +227,31 @@ jobs:
           base_suffix: '_base'
           current_suffix: '_pr'
 
-      - name: Comment diff
+      # Upload benchmark results as artifact for secure comment job
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-comparison
+          path: benchmark-comparison.md
+          retention-days: 1
+
+  # Secure job for commenting - no code checkout, only artifact download
+  comment-results:
+    name: Comment benchmark results on PR
+    needs: [check-changes, benchmark]
+    if: needs.benchmark.result == 'success'
+    runs-on: ubuntu-latest
+    
+    steps:
+      # SECURITY: Do NOT checkout PR code in this job
+      # This job has elevated permissions to comment but never touches untrusted code
+      
+      - name: Download benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-comparison
+          
+      - name: Comment benchmark diff on PR
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/compare-benchmark.yml
+++ b/.github/workflows/compare-benchmark.yml
@@ -2,7 +2,7 @@ name: Aztec Benchmark Diff
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -12,42 +12,42 @@ env:
   BENCH_DIR: ./benchmarks
 
 jobs:
-  check-changes:
-    name: Check for benchmark-relevant changes
-    runs-on: ubuntu-latest
-    outputs:
-      should-benchmark: ${{ steps.changes.outputs.should-benchmark }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  # check-changes:
+  #   name: Check for benchmark-relevant changes
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     should-benchmark: ${{ steps.changes.outputs.should-benchmark }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Check for relevant changes
-        id: changes
-        run: |
-          echo "Checking for changes that would affect benchmarks..."
+  #     - name: Check for relevant changes
+  #       id: changes
+  #       run: |
+  #         echo "Checking for changes that would affect benchmarks..."
           
-          # Check if Noir contracts, config, or benchmarks changed
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^(src/nr/|Nargo\.toml|benchmarks/)'; then
-            echo "📝 Noir contracts, config, or benchmark files changed"
-            echo "should-benchmark=true" >> $GITHUB_OUTPUT
-          else
-            echo "📁 No Noir contract, config, or benchmark changes detected"
+  #         # Check if Noir contracts, config, or benchmarks changed
+  #         if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '^(src/nr/|Nargo\.toml|benchmarks/)'; then
+  #           echo "📝 Noir contracts, config, or benchmark files changed"
+  #           echo "should-benchmark=true" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "📁 No Noir contract, config, or benchmark changes detected"
             
-            # Check for AZTEC_VERSION change in package.json
-            if git diff ${{ github.event.pull_request.base.sha }} HEAD package.json | grep -q 'aztecVersion'; then
-              echo "🔄 AZTEC_VERSION changed in package.json"
-              echo "should-benchmark=true" >> $GITHUB_OUTPUT
-            else
-              echo "⏭️ No benchmark-relevant changes detected, skipping benchmarks"
-              echo "should-benchmark=false" >> $GITHUB_OUTPUT
-            fi
-          fi
+  #           # Check for AZTEC_VERSION change in package.json
+  #           if git diff ${{ github.event.pull_request.base.sha }} HEAD package.json | grep -q 'aztecVersion'; then
+  #             echo "🔄 AZTEC_VERSION changed in package.json"
+  #             echo "should-benchmark=true" >> $GITHUB_OUTPUT
+  #           else
+  #             echo "⏭️ No benchmark-relevant changes detected, skipping benchmarks"
+  #             echo "should-benchmark=false" >> $GITHUB_OUTPUT
+  #           fi
+  #         fi
 
   benchmark:
     name: Run benchmark comparison
-    needs: check-changes
+    # needs: check-changes
     # if: needs.check-changes.outputs.should-benchmark == 'true'
     runs-on: ubuntu-latest
 
@@ -63,7 +63,7 @@ jobs:
       - name: Install and cache yarn
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install Aztec CLI
@@ -238,7 +238,9 @@ jobs:
   # Secure job for commenting - no code checkout, only artifact download
   comment-results:
     name: Comment benchmark results on PR
-    needs: [check-changes, benchmark]
+    needs: [benchmark]
+    # needs: [check-changes, benchmark]
+    # if: needs.check-changes.outputs.should-benchmark == 'true' && needs.benchmark.result == 'success'
     if: needs.benchmark.result == 'success'
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
The `peter-evans/create-or-update-comment` action fails on fork PRs with "Resource not accessible by integration" due to GitHub Actions token restrictions.

### Solution
Implemented secure `workflow_run` approach following [GitHub Security Lab best practices](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).

### Security Architecture
Split into two isolated workflows:
- **`benchmark.yml`**: Uses `pull_request` trigger (limited permissions, safe for untrusted fork code)
- **`comment-benchmark.yml`**: Uses `workflow_run` trigger (elevated permissions, **never checks out PR code**)

### Execution Context
- **`benchmark.yml`**: Runs in fork context with limited permissions, can safely build untrusted code
- **`comment-benchmark.yml`**: Runs in target repo context with write permissions, only processes trusted artifacts
- **Data transfer**: Secure artifact-based communication prevents secret exposure

### Technical Implementation
1. **Benchmark workflow**: `pull_request` trigger, builds both base and PR code, uploads results as artifacts
2. **Comment workflow**: `workflow_run` trigger, downloads artifacts, posts comments on PRs
3. **Change detection**: GitHub API-based file change detection (works with fork PRs)
4. **Conditional execution**: Only runs benchmarks when Noir contracts, config, or Aztec version changes

### Result
- ✅ **Fork PRs**: Now receive automated benchmark comments
- ✅ **Same-repo PRs**: Continue working as before  
- ✅ **Security**: No PWN request vulnerabilities
- ✅ **Compliance**: Follows GitHub Security Lab guidelines