### PR TITLE
feat: yarn ccc -> yarn build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 The complete build pipeline includes cleaning, compiling Noir contracts, and generating TypeScript artifacts:
 
 ```bash
-yarn ccc
+yarn build
 ```
 
 This runs:
@@ -181,7 +181,7 @@ The `increment()` function is private but enqueues a public `increment_internal(
 ## Development workflow
 
 1. **Modify Noir contracts** in `src/nr/`
-2. **Run `yarn ccc`** to rebuild and regenerate TypeScript artifacts
+2. **Run `yarn build`** to rebuild and regenerate TypeScript artifacts
 3. **Write tests** in `src/ts/` using generated artifacts
 4. **Run tests** with `yarn test` (sandbox starts automatically)
 5. **Format code** with `yarn lint:prettier`

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "clean": "rm -rf ./src/artifacts ./target",
+    "clean": "rm -rf ./src/artifacts ./target codegenCache.json",
     "codegen": "aztec codegen target --outdir src/artifacts",
     "compile": "aztec-nargo compile",
     "test": "yarn test:nr && yarn test:js",
     "test:js": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --no-cache --runInBand --config jest.integration.config.json",
     "test:nr": "aztec test",
     "lint:prettier": "prettier '**/*.{js,ts}' --write",
-    "ccc": "yarn clean && yarn compile && yarn codegen -f",
+    "build": "yarn compile && yarn codegen -f",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/pull/15511 caches verification keys between re-compilations. Replace `yarn ccc` with `yarn build` that does not do `yarn clean`. The cached vks are stored in `target/cache` btw