### PR TITLE
fix: include yarn ccc as defined in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 The complete build pipeline includes cleaning, compiling Noir contracts, and generating TypeScript artifacts:
 
 ```bash
-yarn build
+yarn ccc
 ```
 
 This runs:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "build": "yarn clean && yarn compile && yarn codegen",
     "clean": "rm -rf ./src/artifacts ./target codegenCache.json",
     "codegen": "aztec codegen target --outdir src/artifacts -f",
     "compile": "aztec-nargo compile && aztec-postprocess-contract",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && yarn compile && yarn codegen",
     "clean": "rm -rf ./src/artifacts ./target codegenCache.json",
     "codegen": "aztec codegen target --outdir src/artifacts -f",
     "compile": "aztec-nargo compile && aztec-postprocess-contract",


### PR DESCRIPTION
The README describes this command, but it is missing from package.json