### PR TITLE
fix: benchmark comparison workflow suffix naming

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -47,11 +47,17 @@ runs:
         path: ${{ inputs.bench-dir }}
         if_no_artifact_found: warn
 
+    - name: Run benchmarks
+      shell: bash
+      run: yarn aztec-benchmark --suffix _latest
+
     - name: Generate Markdown diff
       uses: defi-wonderland/aztec-benchmark/action@main
       with:
-        base_suffix: '_latest'
-        current_suffix: '_new'
+        reports_dir: ${{ inputs.bench-dir }}
+        base_suffix: '_baseline'
+        current_suffix: '_latest'
+        only_report: true
 
     - name: Comment diff on PR
       uses: peter-evans/create-or-update-comment@v4
@@ -62,14 +68,11 @@ runs:
     - name: Prepare benchmark files for upload
       shell: bash
       run: |
-        # Remove old _latest files (from base branch fetch) before renaming
-        rm -f ${{ inputs.bench-dir }}/*_latest.benchmark.json
-        
-        # Rename _new files to _latest (the canonical stored format)
-        for file in ${{ inputs.bench-dir }}/*_new.benchmark.json; do
+        # Remove downloaded baseline files and rename current results to baseline format
+        rm -f ${{ inputs.bench-dir }}/*_baseline.benchmark.json
+        for file in ${{ inputs.bench-dir }}/*_latest.benchmark.json; do
           if [ -f "$file" ]; then
-            new_name="${file/_new.benchmark.json/_latest.benchmark.json}"
-            echo "Renaming $file -> $new_name"
+            new_name="${file/_latest.benchmark.json/_baseline.benchmark.json}"
             mv "$file" "$new_name"
           fi
         done
@@ -87,6 +90,6 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-baseline-${{ steps.encode-head.outputs.head-ref-encoded }}
-        path: ${{ inputs.bench-dir }}/*_latest.benchmark.json
+        path: ${{ inputs.bench-dir }}/*_baseline.benchmark.json
         retention-days: 90
         if-no-files-found: error

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -42,12 +42,12 @@ jobs:
           run-codegen: 'true'
 
       - name: Run benchmarks
-        run: yarn aztec-benchmark --suffix _latest
+        run: yarn aztec-benchmark --suffix _baseline
 
       - name: List baseline files
         run: |
           echo "Baseline files for branch: ${{ github.ref_name }}"
-          ls -lh ${{ env.BENCH_DIR }}/*_latest.benchmark.json
+          ls -lh ${{ env.BENCH_DIR }}/*_baseline.benchmark.json
 
       - name: Encode branch name
         id: encode
@@ -61,6 +61,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-baseline-${{ steps.encode.outputs.branch-encoded }}
-          path: ${{ env.BENCH_DIR }}/*_latest.benchmark.json
+          path: ${{ env.BENCH_DIR }}/*_baseline.benchmark.json
           retention-days: 90
           if-no-files-found: error


### PR DESCRIPTION
## Summary

- Fix benchmark comparison workflow showing `Base: 0` by correcting suffix naming mismatch
- Add explicit benchmark execution step in PR workflow
- Use `only_report: true` flag to skip external action's unreliable benchmark execution

## Root Cause

The comparison was failing because:
1. `update-baseline.yml` created files with `_latest` suffix
2. PR workflow expected to download baseline and compare with `_new` suffix
3. External action's implicit benchmark execution via `npx aztec-benchmark` was unreliable
4. No `_new` files were generated → comparison returned empty/zero results

## Changes

**`.github/actions/benchmark/action.yml`:**
- Add explicit `Run benchmarks` step: `yarn aztec-benchmark --suffix _latest`
- Add `reports_dir: ${{ inputs.bench-dir }}`
- Change `base_suffix` from `'_latest'` to `'_baseline'`
- Change `current_suffix` from `'_new'` to `'_latest'`
- Add `only_report: true` to use external action only for comparison, not execution
- Update file cleanup/upload paths to use `_baseline` suffix

**`.github/workflows/update-baseline.yml`:**
- Change benchmark suffix from `_latest` to `_baseline`
- Update file listing and upload paths to use `_baseline` suffix

## New Flow

**update-baseline.yml** (on push to dev/main):
1. Runs `yarn aztec-benchmark --suffix _baseline`
2. Uploads `*_baseline.benchmark.json` as artifact

**benchmark/action.yml** (on PR):
1. Downloads baseline artifact (`*_baseline.benchmark.json`)
2. Runs `yarn aztec-benchmark --suffix _latest` (generates current)
3. External action compares `_baseline` vs `_latest` (only_report: true)
4. Posts comparison, renames files to `_baseline`, uploads for PR branch

## Test plan

- [ ] After merge, `update-baseline.yml` workflow runs and creates baseline with `_baseline` suffix
- [ ] Future PRs correctly download baseline and generate comparison reports with proper values

🤖 Generated with [Claude Code](https://claude.com/claude-code)