### PR TITLE
chore: upgrade aztec to 4.0.0-devnet.2-patch.0

### DIFF
--- a/benchmarks/counter.benchmark.ts
+++ b/benchmarks/counter.benchmark.ts
@@ -1,10 +1,8 @@
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { type ContractFunctionInteractionCallIntent } from "@aztec/aztec.js/authorization";
-import {
-  registerInitialLocalNetworkAccountsInWallet,
-  TestWallet,
-} from "@aztec/test-wallet/server";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import { registerInitialLocalNetworkAccountsInWallet } from "@aztec/wallets/testing";
 import {
   Benchmark,
   type BenchmarkContext,
@@ -14,7 +12,7 @@ import { CounterContract } from "../src/artifacts/Counter.js";
 
 // Extend the BenchmarkContext from the new package
 interface CounterBenchmarkContext extends BenchmarkContext {
-  wallet: TestWallet;
+  wallet: EmbeddedWallet;
   deployer: AztecAddress;
   accounts: AztecAddress[];
   counterContract: CounterContract;
@@ -30,7 +28,7 @@ export default class CounterContractBenchmark extends Benchmark {
     const aztecNode = createAztecNodeClient("http://localhost:8080");
     await waitForNode(aztecNode);
 
-    const wallet: TestWallet = await TestWallet.create(aztecNode);
+    const wallet: EmbeddedWallet = await EmbeddedWallet.create(aztecNode);
     const accounts: AztecAddress[] =
       await registerInitialLocalNetworkAccountsInWallet(wallet);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec-boilerplate",
-  "version": "4.0.0-devnet.1-patch.0",
+  "version": "4.0.0-devnet.2-patch.0",
   "repository": "https://github.com/defi-wonderland/aztec-boilerplate.git",
   "author": "Wonderland",
   "license": "MIT",
@@ -21,14 +21,14 @@
     "*.{js,ts}": "prettier --write -u"
   },
   "dependencies": {
-    "@aztec/accounts": "4.0.0-devnet.1-patch.0",
-    "@aztec/aztec.js": "4.0.0-devnet.1-patch.0",
-    "@aztec/entrypoints": "4.0.0-devnet.1-patch.0",
-    "@aztec/noir-contracts.js": "4.0.0-devnet.1-patch.0",
-    "@aztec/pxe": "4.0.0-devnet.1-patch.0",
-    "@aztec/stdlib": "4.0.0-devnet.1-patch.0",
-    "@aztec/test-wallet": "4.0.0-devnet.1-patch.0",
-    "@defi-wonderland/aztec-benchmark": "4.0.0-devnet.1-patch.0",
+    "@aztec/accounts": "4.0.0-devnet.2-patch.0",
+    "@aztec/aztec.js": "4.0.0-devnet.2-patch.0",
+    "@aztec/entrypoints": "4.0.0-devnet.2-patch.0",
+    "@aztec/noir-contracts.js": "4.0.0-devnet.2-patch.0",
+    "@aztec/pxe": "4.0.0-devnet.2-patch.0",
+    "@aztec/stdlib": "4.0.0-devnet.2-patch.0",
+    "@aztec/wallets": "4.0.0-devnet.2-patch.0",
+    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-28ebeca/defi-wonderland-aztec-benchmark-4.0.0-devnet.2-patch.0-prerelease.28ebeca.tgz",
     "@types/node": "25.0.10"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "vitest": "4.0.17"
   },
   "config": {
-    "aztecVersion": "4.0.0-devnet.1-patch.0"
+    "aztecVersion": "4.0.0-devnet.2-patch.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {

--- a/src/nr/counter_contract/Nargo.toml
+++ b/src/nr/counter_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 authors = [""]
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.1-patch.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.0", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/ts/counter.test.ts
+++ b/src/ts/counter.test.ts
@@ -1,28 +1,24 @@
 import { CounterContract } from "../artifacts/Counter.js";
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import {
-  registerInitialLocalNetworkAccountsInWallet,
-  TestWallet,
-} from "@aztec/test-wallet/server";
+import { EmbeddedWallet } from "@aztec/wallets/embedded";
+import { registerInitialLocalNetworkAccountsInWallet } from "@aztec/wallets/testing";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { deployCounter } from "./utils.js";
 import { AztecAddress } from "@aztec/stdlib/aztec-address";
 
 describe("Counter Contract", () => {
-  let wallet: TestWallet;
+  let wallet: EmbeddedWallet;
   let alice: AztecAddress;
   let counter: CounterContract;
 
   beforeAll(async () => {
     const aztecNode = await createAztecNodeClient("http://localhost:8080", {});
-    wallet = await TestWallet.create(
-      aztecNode,
-      {
+    wallet = await EmbeddedWallet.create(aztecNode, {
+      pxeConfig: {
         dataDirectory: "pxe-test",
         proverEnabled: false,
       },
-      {},
-    );
+    });
 
     // Local network starts with predeployed funded accounts; register them in PXE for private execution.
     [alice] = await registerInitialLocalNetworkAccountsInWallet(wallet);


### PR DESCRIPTION
Applied migration: @aztec/test-wallet -> @aztec/wallets (EmbeddedWallet).
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Upgrade Aztec framework dependencies to version 4.0.0-devnet.2-patch.0 and migrate wallet implementation from TestWallet to EmbeddedWallet with updated API.

Main changes:
- Updated all @aztec/* dependencies to 4.0.0-devnet.2-patch.0; replaced @aztec/test-wallet with @aztec/wallets package
- Migrated TestWallet to EmbeddedWallet across benchmark and test files with new constructor signature accepting pxeConfig object
- Updated Noir dependency tag in Nargo.toml and project version to match new framework release

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
