### PR TITLE
chore: upgrade aztec to 4.2.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
 
   benchmark:
-    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@chore/next
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@prerelease-022ee63
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
 
   benchmark:
-    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@4.0.0-devnet.2-patch.1
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@chore/next
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,7 @@ jobs:
   benchmark:
     uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@chore/next
     permissions:
+      contents: read
       pull-requests: write
       issues: write
       actions: read

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   baseline:
-    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@chore/next
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@prerelease-022ee63
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   baseline:
-    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@4.0.0-devnet.2-patch.1
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@chore/next
     permissions:
       contents: read
       actions: write

--- a/benchmarks/counter.benchmark.ts
+++ b/benchmarks/counter.benchmark.ts
@@ -34,9 +34,10 @@ export default class CounterContractBenchmark extends Benchmark {
 
     const [deployer] = accounts;
 
-    const counterContract = await CounterContract.deploy(wallet, deployer).send(
-      { from: deployer },
-    );
+    const { contract: counterContract } = await CounterContract.deploy(
+      wallet,
+      deployer,
+    ).send({ from: deployer });
 
     return { wallet, deployer, accounts, counterContract };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec-boilerplate",
-  "version": "4.0.0-devnet.2-patch.1",
+  "version": "4.2.0-nightly.20260414",
   "repository": "https://github.com/defi-wonderland/aztec-boilerplate.git",
   "author": "Wonderland",
   "license": "MIT",
@@ -21,14 +21,14 @@
     "*.{js,ts}": "prettier --write -u"
   },
   "dependencies": {
-    "@aztec/accounts": "4.0.0-devnet.2-patch.1",
-    "@aztec/aztec.js": "4.0.0-devnet.2-patch.1",
-    "@aztec/entrypoints": "4.0.0-devnet.2-patch.1",
-    "@aztec/noir-contracts.js": "4.0.0-devnet.2-patch.1",
-    "@aztec/pxe": "4.0.0-devnet.2-patch.1",
-    "@aztec/stdlib": "4.0.0-devnet.2-patch.1",
-    "@aztec/wallets": "4.0.0-devnet.2-patch.1",
-    "@defi-wonderland/aztec-benchmark": "4.0.0-devnet.2-patch.1",
+    "@aztec/accounts": "4.2.0-nightly.20260414",
+    "@aztec/aztec.js": "4.2.0-nightly.20260414",
+    "@aztec/entrypoints": "4.2.0-nightly.20260414",
+    "@aztec/noir-contracts.js": "4.2.0-nightly.20260414",
+    "@aztec/pxe": "4.2.0-nightly.20260414",
+    "@aztec/stdlib": "4.2.0-nightly.20260414",
+    "@aztec/wallets": "4.2.0-nightly.20260414",
+    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-c922ff4/defi-wonderland-aztec-benchmark-4.2.0-nightly.20260414-prerelease.c922ff4.tgz",
     "@types/node": "25.0.10"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "vitest": "4.0.17"
   },
   "config": {
-    "aztecVersion": "4.0.0-devnet.2-patch.1"
+    "aztecVersion": "4.2.0-nightly.20260414"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec-boilerplate",
-  "version": "4.2.0-nightly.20260414",
+  "version": "4.2.0-rc.1",
   "repository": "https://github.com/defi-wonderland/aztec-boilerplate.git",
   "author": "Wonderland",
   "license": "MIT",
@@ -21,14 +21,14 @@
     "*.{js,ts}": "prettier --write -u"
   },
   "dependencies": {
-    "@aztec/accounts": "4.2.0-nightly.20260414",
-    "@aztec/aztec.js": "4.2.0-nightly.20260414",
-    "@aztec/entrypoints": "4.2.0-nightly.20260414",
-    "@aztec/noir-contracts.js": "4.2.0-nightly.20260414",
-    "@aztec/pxe": "4.2.0-nightly.20260414",
-    "@aztec/stdlib": "4.2.0-nightly.20260414",
-    "@aztec/wallets": "4.2.0-nightly.20260414",
-    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-c922ff4/defi-wonderland-aztec-benchmark-4.2.0-nightly.20260414-prerelease.c922ff4.tgz",
+    "@aztec/accounts": "4.2.0-rc.1",
+    "@aztec/aztec.js": "4.2.0-rc.1",
+    "@aztec/entrypoints": "4.2.0-rc.1",
+    "@aztec/noir-contracts.js": "4.2.0-rc.1",
+    "@aztec/pxe": "4.2.0-rc.1",
+    "@aztec/stdlib": "4.2.0-rc.1",
+    "@aztec/wallets": "4.2.0-rc.1",
+    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-49f460a/defi-wonderland-aztec-benchmark-4.2.0-rc.1-prerelease.49f460a.tgz",
     "@types/node": "25.0.10"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "vitest": "4.0.17"
   },
   "config": {
-    "aztecVersion": "4.2.0-nightly.20260414"
+    "aztecVersion": "4.2.0-rc.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec-boilerplate",
-  "version": "4.2.0-rc.1",
+  "version": "4.2.0",
   "repository": "https://github.com/defi-wonderland/aztec-boilerplate.git",
   "author": "Wonderland",
   "license": "MIT",
@@ -21,14 +21,14 @@
     "*.{js,ts}": "prettier --write -u"
   },
   "dependencies": {
-    "@aztec/accounts": "4.2.0-rc.1",
-    "@aztec/aztec.js": "4.2.0-rc.1",
-    "@aztec/entrypoints": "4.2.0-rc.1",
-    "@aztec/noir-contracts.js": "4.2.0-rc.1",
-    "@aztec/pxe": "4.2.0-rc.1",
-    "@aztec/stdlib": "4.2.0-rc.1",
-    "@aztec/wallets": "4.2.0-rc.1",
-    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-49f460a/defi-wonderland-aztec-benchmark-4.2.0-rc.1-prerelease.49f460a.tgz",
+    "@aztec/accounts": "4.2.0",
+    "@aztec/aztec.js": "4.2.0",
+    "@aztec/entrypoints": "4.2.0",
+    "@aztec/noir-contracts.js": "4.2.0",
+    "@aztec/pxe": "4.2.0",
+    "@aztec/stdlib": "4.2.0",
+    "@aztec/wallets": "4.2.0",
+    "@defi-wonderland/aztec-benchmark": "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-022ee63/defi-wonderland-aztec-benchmark-4.2.0-prerelease.022ee63.tgz",
     "@types/node": "25.0.10"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "vitest": "4.0.17"
   },
   "config": {
-    "aztecVersion": "4.2.0-rc.1"
+    "aztecVersion": "4.2.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {

--- a/src/nr/counter_contract/Nargo.toml
+++ b/src/nr/counter_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 authors = [""]
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-nightly.20260414", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-rc.1", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/nr/counter_contract/Nargo.toml
+++ b/src/nr/counter_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 authors = [""]
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-rc.1", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/nr/counter_contract/Nargo.toml
+++ b/src/nr/counter_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 authors = [""]
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.0.0-devnet.2-patch.1", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v4.2.0-nightly.20260414", directory = "noir-projects/aztec-nr/aztec" }

--- a/src/ts/counter.test.ts
+++ b/src/ts/counter.test.ts
@@ -29,15 +29,17 @@ describe("Counter Contract", () => {
   });
 
   it("e2e", async () => {
-    const owner = await counter.methods.get_owner().simulate({
+    const { result: owner } = await counter.methods.get_owner().simulate({
       from: alice,
     });
     expect(owner).toStrictEqual(alice);
     // default counter's value is 0
     expect(
-      await counter.methods.get_counter().simulate({
-        from: alice,
-      }),
+      (
+        await counter.methods.get_counter().simulate({
+          from: alice,
+        })
+      ).result,
     ).toBe(0n);
     // call to `increment`
     await counter.methods.increment().send({
@@ -45,9 +47,11 @@ describe("Counter Contract", () => {
     });
     // now the counter should be incremented.
     expect(
-      await counter.methods.get_counter().simulate({
-        from: alice,
-      }),
+      (
+        await counter.methods.get_counter().simulate({
+          from: alice,
+        })
+      ).result,
     ).toBe(1n);
   });
 });

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -13,7 +13,7 @@ export async function deployCounter(
   owner: AztecAddress,
 ): Promise<CounterContract> {
   const deployerAddress = (await deployer.getAccounts())[0]!.item;
-  const contract = await CounterContract.deploy(deployer, owner).send({
+  const { contract } = await CounterContract.deploy(deployer, owner).send({
     from: deployerAddress,
   });
   return contract;

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,59 +636,59 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz#f1137f56209ccc69c15f826242cbf37f828617dd"
   integrity sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==
 
-"@aztec/accounts@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-4.2.0-rc.1.tgz#2dcd215578af1888ab65254769a88d08d22873f4"
-  integrity sha512-vsKpXUzJn6GpmMK2V1XyjyDs2qpE1dvvngQKpNMGSBVwdRm9O/vhu7C3J5UEvzdHbMDNJAUkK8d5RMFhmezKsg==
+"@aztec/accounts@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-4.2.0.tgz#378f4f88f9f8b1073e24d25270d5044149fcfe0b"
+  integrity sha512-nf5IPOPRSvg6shSGcj0iko8IA8CwZc2u9kSv47+Cr9ttQkh0Ugj0nxvBjFykl36NiP6sJ1lqCBpoGMXZ6SS2rw==
   dependencies:
-    "@aztec/aztec.js" "4.2.0-rc.1"
-    "@aztec/entrypoints" "4.2.0-rc.1"
-    "@aztec/ethereum" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/aztec.js" "4.2.0"
+    "@aztec/entrypoints" "4.2.0"
+    "@aztec/ethereum" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-4.2.0-rc.1.tgz#0e4e499d265a722434ff9564b7c950d5f3b5be14"
-  integrity sha512-PxkQMvVlFzwJVMDuhHqJD6ItlguIbYFn8dOmZw6R5kXJdLLI6WXtBZgo4KR06qbkAKaawkEFHy2YSmxLUOw47Q==
+"@aztec/aztec.js@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-4.2.0.tgz#54e3896803a8bff8117c7db56d09fb0e31e1ff71"
+  integrity sha512-q+BispWWUqQihCRqr2DHNHP5mXKvmKPoXrUH1+rsKBxIK2QfEl9juNhEhbvEjf23uBs5/7b91aF/m62bxnJzAA==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/entrypoints" "4.2.0-rc.1"
-    "@aztec/ethereum" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/l1-artifacts" "4.2.0-rc.1"
-    "@aztec/protocol-contracts" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/entrypoints" "4.2.0"
+    "@aztec/ethereum" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/l1-artifacts" "4.2.0"
+    "@aztec/protocol-contracts" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     axios "^1.13.5"
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-4.2.0-rc.1.tgz#282b57dabb9b5a36d1647f8424b3e2e785549305"
-  integrity sha512-iCn+YQd5+ATR8OGznUDDxCTQJYjBlf+qH0P1F8S52YaCoAhpyEsueOoG7EfevAdg6vzGu5xZEc0s0mHdQK6R+A==
+"@aztec/bb-prover@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-4.2.0.tgz#e8f2e7d8252649b0176955ed1267d0a080b489c6"
+  integrity sha512-g91bXdg8uNGny6OWoRwdzOckOZQ/ofWEcI1yC+TXOwFPjJZ9W4DX01SKV8l7y16a7bjN3137VPBZ+OqcwVW17Q==
   dependencies:
-    "@aztec/bb.js" "4.2.0-rc.1"
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
-    "@aztec/noir-protocol-circuits-types" "4.2.0-rc.1"
-    "@aztec/noir-types" "4.2.0-rc.1"
-    "@aztec/simulator" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
-    "@aztec/telemetry-client" "4.2.0-rc.1"
-    "@aztec/world-state" "4.2.0-rc.1"
+    "@aztec/bb.js" "4.2.0"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/noir-noirc_abi" "4.2.0"
+    "@aztec/noir-protocol-circuits-types" "4.2.0"
+    "@aztec/noir-types" "4.2.0"
+    "@aztec/simulator" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
+    "@aztec/telemetry-client" "4.2.0"
+    "@aztec/world-state" "4.2.0"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-4.2.0-rc.1.tgz#3c43272147e9b6377fbe3b1e066cc662f26f88ad"
-  integrity sha512-K5Tp3SdHP9clJ1V6P2qDlt1y/bJSzF+w3kPA+vAfQdHtazSwoqG1FomO7swk3mOMFcQA7cqiwMlv203hAhh/mw==
+"@aztec/bb.js@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-4.2.0.tgz#60838a9f03346fe53aeced86d7674ca0788d4cf6"
+  integrity sha512-NHcQtXGsi3djJPK8QoELzK826Wm/mmpwdhM8lBdQCOmvpr6wRlyIvW/SzPUBO8sSbuE4SBGGZ7LeeB/Vt3UGSQ==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -697,54 +697,54 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-4.2.0-rc.1.tgz#0c34059f4b6e1fd41890f011a2df0659758e5765"
-  integrity sha512-qv6SeslnJQFFBPWdqgM15lTaAnNlhPiuCS34P6iKSM/ZYHAC3PbA1nZgrOZaS3E1O3yY6qCZJBVvnlEWv7uF7g==
+"@aztec/blob-lib@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-4.2.0.tgz#50317bb02dbaab4f7e2f5017e06d324c0040e53a"
+  integrity sha512-fuNQfx33iDbmCfFRmFsTQLlpR7frbPJW2LxbwN4rwGsy/3HfihIFI3C/sb7BTn8TkRSkKzxf8tPP1i5eQHbjnA==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-4.2.0-rc.1.tgz#ac099a52c8b8f4229048a910ee492e2b843656c4"
-  integrity sha512-A36tSQ2zRbiHY0DwffdyYobVjb4U0nCi6Cvq/fvh/dgouKhsJOU0n9P7SRmCWGupm25ooeZvc4WEmh5XleUYDA==
+"@aztec/builder@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-4.2.0.tgz#08249a3d99956fa793c12b1f31bdb91e72b25afb"
+  integrity sha512-eioKvF16HaY+gj1OSjfxxleBBGP0ef5WCnbMnQQFNBGvZNpbgdHu35pXgiOhHzuJHnpLLo3SOqgW2nKWvHZMxw==
   dependencies:
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     commander "^12.1.0"
 
-"@aztec/constants@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-4.2.0-rc.1.tgz#d5e358c85871858ed68bb7a27b5e0ee66ee57619"
-  integrity sha512-aAts5chSX451IV/XySEIjKLJNRPn/iUZELJmkjKTce1kRhi1PD5bFiHvnd/97Of6xsqRyyja4QuBdlJ2ihAepA==
+"@aztec/constants@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-4.2.0.tgz#45faa577ed6b5c94a9cf2df4836e3740a385bf06"
+  integrity sha512-ZdCYXJDtPY0MdvPuA9C+wL2rdomH8YoOs8Za7Bg9XFGVD6dCqESs8tPr87s0OvrKrd3b0EhIn59Nz4dT8IrJSQ==
   dependencies:
-    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-4.2.0-rc.1.tgz#584a5574fc1f8a2a11375e6c857409de8aa94595"
-  integrity sha512-LafdJUkJbD9TZ6fHcXQNVSJG3VnXADylsIXiJj6Kyso7F+U/RgEO2whTPilkkBYVuWvn2/zm3Rx1+IXL4+R8jw==
+"@aztec/entrypoints@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-4.2.0.tgz#e1f3d2711da53cf35e98895744b0653a24b204e3"
+  integrity sha512-6O3ba9evuRwEjHUfr629Y/ZC2YDathO8Nee3N+ryIlidVBc1MHZ7BNh08nSxnU6fbAn+0sFgXnsoC7tCTgv1GQ==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/protocol-contracts" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/protocol-contracts" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/ethereum@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-4.2.0-rc.1.tgz#3643e7091a636a7c42c2b6db114e768c26e54531"
-  integrity sha512-EKE+hJyAx720j/DpGTahLhcUOgXZ/iN0vz37obvmoMyMeDQ+rdUqyrLCLipW5UY5dBZ9epzUiF56xJSuxgfnbQ==
+"@aztec/ethereum@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-4.2.0.tgz#a65c2e63eca7c9e6113e1f6de321999908f443eb"
+  integrity sha512-mCjon9KgcX0W9yIceeDgWJh4W520TrEZXFMH3fe5Ricp/iwtcDm+mXCqyAvt4RMKcCFh2RAv2qBBYQRFoTEusw==
   dependencies:
-    "@aztec/blob-lib" "4.2.0-rc.1"
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/l1-artifacts" "4.2.0-rc.1"
+    "@aztec/blob-lib" "4.2.0"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/l1-artifacts" "4.2.0"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
@@ -753,12 +753,12 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-4.2.0-rc.1.tgz#c15206c3a0d178c9b2da0b55f7562ff1316a21dc"
-  integrity sha512-+RgkC0EZxuAD3EnNe3xljYR5hCJqHjQj7DegLs/anaL55vydcWLFaNaN+CgcGKHV1ldWpi3YNYV6Aw7ghoV/kQ==
+"@aztec/foundation@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-4.2.0.tgz#2721fdf0a0cee5187b450873fe8ed5aa631a148e"
+  integrity sha512-UZc9VfFtSw/zCvpQtsgyz9bdztuX1vaa0g5jgImXsMAfrvPJPkg66IUmMY5rmzvpP1mZ4ySOZpXJ4XtQAaQG4w==
   dependencies:
-    "@aztec/bb.js" "4.2.0-rc.1"
+    "@aztec/bb.js" "4.2.0"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
     "@noble/hashes" "^1.6.1"
@@ -781,140 +781,140 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-4.2.0-rc.1.tgz#9d8ca3fd061be38dd03d65230ec3bcb14f58f075"
-  integrity sha512-01bXCld4reQVNWIlHeHpNPonCk45iZSeRVDP0J9geCjEX8PNgUo33oX6wv1HdCQ4bZ09Cqz48utG/5HvaWx3aA==
+"@aztec/key-store@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-4.2.0.tgz#9590df886b442614192c07dd7373d6e23df2209d"
+  integrity sha512-hdwrwYQlPu2v7cILLVWEFDC3XRUvH8/sDZ1e/cKrvHQZw591NI3T2eH9s2i5kA/Cs/whs06Io/ydW1bvqMJFEg==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/kv-store" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/kv-store" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     tslib "^2.4.0"
 
-"@aztec/kv-store@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-4.2.0-rc.1.tgz#61a427e5c5f96ea429572529220522c12eefd797"
-  integrity sha512-iEK7+ltXSRp/V5gNz/J9Mx7AOkYiNwoFGwmSn1E/ieghkta6IvYeu/QmwLHvrMXSGBQFirB73L8eY8ciGFsxYQ==
+"@aztec/kv-store@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-4.2.0.tgz#ae72fec4da2ada7a3d3698a2d9a2606610b4bcb1"
+  integrity sha512-GXVQCJWVhvaggDqWRY7jfYueJ4qbQQekh0G8byv2hP7zVTN/5UrMClneghB98bKt09l3TaOWNSD8MnYpbdd5rw==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/ethereum" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/native" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/ethereum" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/native" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-4.2.0-rc.1.tgz#ecb9a83b6d75c8d68125c90699abb48d6d021497"
-  integrity sha512-F0xP6Vq0/mpFHQ4rLOqVaBcdfBe7LYm0zq1KUxNqV6FIWOTXHzWuCdCn55jG3UE70DE2y1QEZqWwJo+v5ZdQlg==
+"@aztec/l1-artifacts@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-4.2.0.tgz#783a50cb10a6805ce393c763c53513fa46e11436"
+  integrity sha512-D2kSBDbxwb8wnS1QoaP1SnXRYgy0FNVHPtmRquvXZz1rwhZ5yzgROtCWhmrNbW4ML82Km+WIahcV/Ix3xvcYtA==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-4.2.0-rc.1.tgz#06c3680a4dbbacb03bec9a65b05d2ba102b86307"
-  integrity sha512-RouJRNEcb4Ua+7IZQs6narCy83Ak6f6eJ/O6r8p9KXF02wuZP8EEyL0G/JuINTMXRCoLqb0QzsVcSi6h6j1UXg==
+"@aztec/merkle-tree@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-4.2.0.tgz#438c4aaf70babcd177e07db701a32c0e5459ded6"
+  integrity sha512-YVdBDy8HPj6WRaRgXj/MJ+mNMg0Pk+pTRp5nBmwmCQ99JCMU5/OMM0L83UekajzfnlRHlk9ZLWh5qndnvfdZlQ==
   dependencies:
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/kv-store" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/kv-store" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-4.2.0-rc.1.tgz#7facb176c26ff1c927207516b20d8b6f72f4160d"
-  integrity sha512-4i5zYLpvBYIyaA5Er1G7VQxF3qLstneedPtp+QN46rJHfSqe+KwCkoRGtCQU3lAVOJTvpUXqtQb5HDluUuEb4g==
+"@aztec/native@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-4.2.0.tgz#64a7644bfc81337ddd2ef9a35cae9efc604410f9"
+  integrity sha512-BhKp+fopCm7/4oWnuq5b4/RjnH+2PTnRvyF8kt+elPZYWY3YQzzY0M6ZEMScREJ164NKrgGVTbXM0zagcGS2mw==
   dependencies:
-    "@aztec/bb.js" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/bb.js" "4.2.0"
+    "@aztec/foundation" "4.2.0"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-4.2.0-rc.1.tgz#4b9ac2a939f8fd2825b51c864264819aaccee8ef"
-  integrity sha512-7ZgzDjMuFFCHLC78iZDEzP8GD76PqHoNo3/CqrJMP/XzLm1QSIKdb0crB+yY5YA5+t3/l5FMy80as+buDcVfWw==
+"@aztec/noir-acvm_js@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-4.2.0.tgz#3f779b4f932c1ea7d5a7ac93be8782fbbfd539ea"
+  integrity sha512-WsSCFDv8os2UNNORocBaSursObI0X45s0pn37iGf/Y0YIJ+xiqSClcQ2TY1n5LY7LLUKgFFKwbmVAavfS18o8w==
 
-"@aztec/noir-contracts.js@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-4.2.0-rc.1.tgz#20f59681911e6ea615f2c5ddbd4653bdc8bd1d29"
-  integrity sha512-iO0vcHh2RwBdsePN6Y0DTJyf2dvnTuLQ7QgrNCC/+4KrlKr9xtbkQRS7lXP2iXxQP1T3c7Yy1TrINcHmvKVZCg==
+"@aztec/noir-contracts.js@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-4.2.0.tgz#bdfb20461d19acbfeff3e53863b86e902d8f3bd0"
+  integrity sha512-RANnxV2qx8xoJo1ThxJorG1XqRW1jzQ/y2x64LSGeNj9+Py0gCgvIc2it2L7dyKtm6I6gJLGb5bPAvy7RxHfig==
   dependencies:
-    "@aztec/aztec.js" "4.2.0-rc.1"
+    "@aztec/aztec.js" "4.2.0"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-4.2.0-rc.1.tgz#325513fbc4ef8bf29a1e75eccffe95f564bfe5e1"
-  integrity sha512-C4gO9CL0d2Zba/pewEAJh+J5vCmfTe6ZqsSZEWVUuc96ROn1a584EPxmflz6OhwbY2rTFLzK4D6NXJUjL8Zixg==
+"@aztec/noir-noir_codegen@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-4.2.0.tgz#f827e4522975de70078c78d1dadd83b98f5ca201"
+  integrity sha512-maHaLnRhfQ1DzL9suBXdEjLojKRIGdXjtCBd4yVsKjxPLc7Nz8Yuk15ZPvHK3onpgLPrplVpIflcMkdZV7tR3g==
   dependencies:
-    "@aztec/noir-types" "4.2.0-rc.1"
+    "@aztec/noir-types" "4.2.0"
     glob "^13.0.6"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-4.2.0-rc.1.tgz#0c73433d60b517662a4f37177d269a6312b08ad2"
-  integrity sha512-AtsRmE4typ3bG56crywfWz0WZ7AMQoJ0Ew2upWe3R4BBgRl9ccfSjrJZJAKMNqiV1hQRgFOQRaxPMgL3Sv+S6w==
+"@aztec/noir-noirc_abi@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-4.2.0.tgz#296d337da645533afae0be694962b9fd6d8e33a6"
+  integrity sha512-pJUZ2SE5LtYfC0C56SvEdFu3rpoAeGjmUaGm9e4EKJRfaBrx95rGPpO416lDKkZjnrgv4loEFblAr30obFe1WQ==
   dependencies:
-    "@aztec/noir-types" "4.2.0-rc.1"
+    "@aztec/noir-types" "4.2.0"
 
-"@aztec/noir-protocol-circuits-types@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-4.2.0-rc.1.tgz#b29649defcb3d442953243504f533da5ed767a0d"
-  integrity sha512-r1iH/bbPXd1Z9g4+gMauRDZxmWXiZJgl93LEMaqIGchvlz2QPGqpUWd99fNMIPmjm4EEShkCb387w6+aqfT2iA==
+"@aztec/noir-protocol-circuits-types@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-4.2.0.tgz#953e2f1665fd98f2d1921081b7116df5435303a7"
+  integrity sha512-wKtnJ1Vau37JeS610/YbU+TC2vojh6kEmLbipJIf0hagVHMJQyTO3d9FRI3on8pN9QffhIjY3THM3E6u3pXvWg==
   dependencies:
-    "@aztec/blob-lib" "4.2.0-rc.1"
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/noir-acvm_js" "4.2.0-rc.1"
-    "@aztec/noir-noir_codegen" "4.2.0-rc.1"
-    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
-    "@aztec/noir-types" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/blob-lib" "4.2.0"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/noir-acvm_js" "4.2.0"
+    "@aztec/noir-noir_codegen" "4.2.0"
+    "@aztec/noir-noirc_abi" "4.2.0"
+    "@aztec/noir-types" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-4.2.0-rc.1.tgz#49ead4bf20f65f57c4c30e1d030b30ce4dfe6d12"
-  integrity sha512-xrSGIbtLUfutxhixd2UFS+AW0K6RDxJfvIF5WGN4DS9KPh+j/F7oJYee/heUvBpj6D7LvxkZZL2T7s/k1xutsA==
+"@aztec/noir-types@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-4.2.0.tgz#9661ec070587b26ea11f182b168e3d662a3d4d45"
+  integrity sha512-NkI2boa4x0SIzPumUsom3bZY8azU/9lKSdFDPKAJQ8htE1KAOl2FshG4FsUCBL9mSaotEnzLG7dO+UzviUkcRg==
 
-"@aztec/protocol-contracts@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-4.2.0-rc.1.tgz#a5d0c29b3631ea410cee11f56044b8cea28ac72a"
-  integrity sha512-VOMuRioeSF8GxrtxZB6ZV9pVbOd1MI9l/2EvyUrT9iX8lXwv1m1p/jAexC/z/FoeikIaWXVNBdAN8Vg66ENiNA==
+"@aztec/protocol-contracts@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-4.2.0.tgz#a23f65f8dd8adde65d5230c905376ea79530ead2"
+  integrity sha512-nZi7PC3ISFws66ArJsVzKTwCOWnuVcLlk9JxEW/Yw13sEJgq8LWQK9IXwmNtAli4uy+pomaSCzLvfu2xXXeH5A==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-4.2.0-rc.1.tgz#2da9fd41542e0bb98093a15e07e6d38793f0cb08"
-  integrity sha512-6UvDqsRMyBdVnQTOaMyrUmDAeDP/cUAhphRIM/Wl4VFKNpxCPf5GyIQ6i+sOxiiIjFg8eYpVys+iQMhVGrdgjQ==
+"@aztec/pxe@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-4.2.0.tgz#2d72acd5b856d863d2c032ee3d9ffe62621d93a4"
+  integrity sha512-CnwAUCx/LzCYODwphSBpVTVJXbDNCALB3DD+4yFU92o+cRZJE7sZRfT9mWP0wK70h7gP3i9NNOVFeBleUk0HQg==
   dependencies:
-    "@aztec/bb-prover" "4.2.0-rc.1"
-    "@aztec/bb.js" "4.2.0-rc.1"
-    "@aztec/builder" "4.2.0-rc.1"
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/ethereum" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/key-store" "4.2.0-rc.1"
-    "@aztec/kv-store" "4.2.0-rc.1"
-    "@aztec/noir-protocol-circuits-types" "4.2.0-rc.1"
-    "@aztec/noir-types" "4.2.0-rc.1"
-    "@aztec/protocol-contracts" "4.2.0-rc.1"
-    "@aztec/simulator" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/bb-prover" "4.2.0"
+    "@aztec/bb.js" "4.2.0"
+    "@aztec/builder" "4.2.0"
+    "@aztec/constants" "4.2.0"
+    "@aztec/ethereum" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/key-store" "4.2.0"
+    "@aztec/kv-store" "4.2.0"
+    "@aztec/noir-protocol-circuits-types" "4.2.0"
+    "@aztec/noir-types" "4.2.0"
+    "@aztec/protocol-contracts" "4.2.0"
+    "@aztec/simulator" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
@@ -922,40 +922,40 @@
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-4.2.0-rc.1.tgz#6cdc2305b9e0517c1a5c3a95a55ba7cb349f44a0"
-  integrity sha512-b6uAo9EW7bgyi6HU3yqxzReHLyxZqoWr+y4BdDwWM3Z9b7UjgXzjajZ4HttFd+T8yEfJzgc8Vt54hUl5pXoWpg==
+"@aztec/simulator@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-4.2.0.tgz#cf21fbb85157228d816c87a3e0dfe80ade5e4c20"
+  integrity sha512-qHoa12NGik3zBJEsHOTNE5PEFOl1ZraB9RyPZ/1yjxouuCIPcK47YAN1FiU7MA8v2+PMBrtzv/SCXHRtcbagGQ==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/native" "4.2.0-rc.1"
-    "@aztec/noir-acvm_js" "4.2.0-rc.1"
-    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
-    "@aztec/noir-protocol-circuits-types" "4.2.0-rc.1"
-    "@aztec/noir-types" "4.2.0-rc.1"
-    "@aztec/protocol-contracts" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
-    "@aztec/telemetry-client" "4.2.0-rc.1"
-    "@aztec/world-state" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/native" "4.2.0"
+    "@aztec/noir-acvm_js" "4.2.0"
+    "@aztec/noir-noirc_abi" "4.2.0"
+    "@aztec/noir-protocol-circuits-types" "4.2.0"
+    "@aztec/noir-types" "4.2.0"
+    "@aztec/protocol-contracts" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
+    "@aztec/telemetry-client" "4.2.0"
+    "@aztec/world-state" "4.2.0"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-4.2.0-rc.1.tgz#709d95e303d54f3969e384e421a71b9cb2bc57b3"
-  integrity sha512-oYnh14hbV1DGL7hor5IFE7GKi1F1DhABc0eKGxskmi9bSPS3/A8EKmiLkF0+uLlCQa+1TLJoZ1z1SG0zlZNnNA==
+"@aztec/stdlib@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-4.2.0.tgz#8e5faeba91d58892cf1ec665696637da800efbff"
+  integrity sha512-W/xv9/Bou5YItcDDJ7ex6/PGMUWXgVWP9c3lfMC6Tt8bErVEg0xui+WIyDB7doz0LwmowiwB2fjHwlFKUyGtQQ==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "4.2.0-rc.1"
-    "@aztec/blob-lib" "4.2.0-rc.1"
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/ethereum" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/l1-artifacts" "4.2.0-rc.1"
-    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
-    "@aztec/validator-ha-signer" "4.2.0-rc.1"
+    "@aztec/bb.js" "4.2.0"
+    "@aztec/blob-lib" "4.2.0"
+    "@aztec/constants" "4.2.0"
+    "@aztec/ethereum" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/l1-artifacts" "4.2.0"
+    "@aztec/noir-noirc_abi" "4.2.0"
+    "@aztec/validator-ha-signer" "4.2.0"
     "@google-cloud/storage" "^7.15.0"
     axios "^1.13.5"
     json-stringify-deterministic "1.0.12"
@@ -969,13 +969,13 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-4.2.0-rc.1.tgz#f0d1498161df774cbe29e54aea470951d847741b"
-  integrity sha512-wlzdrPk+z7FtxEcn8IwneQpz6UUsr8NKGDPjaWo+OTvzk+v75b6Kb7Aijq+IZTlNUkeC/T3FH7rEyan1VJM4WQ==
+"@aztec/telemetry-client@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-4.2.0.tgz#3fbf1d82797e7648cb5a8ac7d397df0df9f9e8e0"
+  integrity sha512-THk/n6L0/9J7gGHsIIp/jtiCtRNZgoZdHXWf1v9TDjW+q+SEKVuvWnIZ8RbHMHvanSPR38/yuzvTPZmebbra/w==
   dependencies:
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -993,58 +993,58 @@
     prom-client "^15.1.3"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/validator-ha-signer@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/validator-ha-signer/-/validator-ha-signer-4.2.0-rc.1.tgz#29455bc3ed92c8cba8781c05497bcf4c558c9588"
-  integrity sha512-+/gyPwi3If/6+/HEM/QbVap9FCqiW4y8whTpZqr8T34bRe00kKZpukLjSmmqMJ7HTMzheSJIyXidTJ2yQEKuWA==
+"@aztec/validator-ha-signer@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/validator-ha-signer/-/validator-ha-signer-4.2.0.tgz#97d5f5cb28b6f941abe4979925caa92fc3422b2f"
+  integrity sha512-74RZzB45e7FG2CKfHI7ML8GxNSIf4aOKIrK4v5kVGyXBzXd5kDc7mDtHpaZ4xmii5+4CxWmvbU+Jw+y36X6iZg==
   dependencies:
-    "@aztec/ethereum" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/ethereum" "4.2.0"
+    "@aztec/foundation" "4.2.0"
     node-pg-migrate "^8.0.4"
     pg "^8.11.3"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/wallet-sdk@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-4.2.0-rc.1.tgz#dd7681c3201e0d733c6b5b51a5eb2693211cafbb"
-  integrity sha512-ryz27f1p/EjKYpbXyOO+FQ/yHF9EAxuEz0GZF4r4wdUhl4foFCuZrPcC7NSTSvY7pdBhEqorfUboOkuZrC/3Yg==
+"@aztec/wallet-sdk@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-4.2.0.tgz#8a2218926d0171d5fe75d98fdfe0ad7faa9b0789"
+  integrity sha512-UiCt3yjktN6KkfncGphBF2gCdmCbiNIfLeZc+XdC6WMY+Cvy8VY6OD33aKotjtSCpL7L/MnqpU4OiAGocKMHAQ==
   dependencies:
-    "@aztec/aztec.js" "4.2.0-rc.1"
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/entrypoints" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/pxe" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/aztec.js" "4.2.0"
+    "@aztec/constants" "4.2.0"
+    "@aztec/entrypoints" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/pxe" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
 
-"@aztec/wallets@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/wallets/-/wallets-4.2.0-rc.1.tgz#40874fa4362a1a7f5d1670aafe4afd6af410e0d5"
-  integrity sha512-EtovGV8vpaAcds4Mm/0XdJ4hL32cKRnQpwr3xMIlwNbtJpp/I6daWiexPAvjhIlzlYT7EB5/INYf/FRDRBZMaw==
+"@aztec/wallets@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/wallets/-/wallets-4.2.0.tgz#828f5cd152362907226d15d55d00750c785ca99b"
+  integrity sha512-C/UAzEJ5lL+eYUq3/Z4vG4uLaJHi7BTPtsT0RGZqCxVPd3iHM1Ouxz3IAgKZ0+C0bc1p+TltIu6FatXZER8+iw==
   dependencies:
-    "@aztec/accounts" "4.2.0-rc.1"
-    "@aztec/aztec.js" "4.2.0-rc.1"
-    "@aztec/entrypoints" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/kv-store" "4.2.0-rc.1"
-    "@aztec/protocol-contracts" "4.2.0-rc.1"
-    "@aztec/pxe" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
-    "@aztec/wallet-sdk" "4.2.0-rc.1"
+    "@aztec/accounts" "4.2.0"
+    "@aztec/aztec.js" "4.2.0"
+    "@aztec/entrypoints" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/kv-store" "4.2.0"
+    "@aztec/protocol-contracts" "4.2.0"
+    "@aztec/pxe" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
+    "@aztec/wallet-sdk" "4.2.0"
 
-"@aztec/world-state@4.2.0-rc.1":
-  version "4.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-4.2.0-rc.1.tgz#bb3503300f732a7106f59d93642efc5136335110"
-  integrity sha512-hgTnqXdIdwehlZQK0cfe6/cDpdQIxtWUjibyw9SBY2hQd11WwLRpSGRBXUhXtb2ioHB18uBfzUspVZetyl2FBQ==
+"@aztec/world-state@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-4.2.0.tgz#049b99449a06cf9acf14dc627fea6a5e3f15808e"
+  integrity sha512-OJD+zxxEfnVywuIET6IVMUhWd94Bej0KFFtOrf9wEciX56JokOIcrvR3hYAJX7jJYCRXMhjVI/0O+zxAGocyRg==
   dependencies:
-    "@aztec/constants" "4.2.0-rc.1"
-    "@aztec/foundation" "4.2.0-rc.1"
-    "@aztec/kv-store" "4.2.0-rc.1"
-    "@aztec/merkle-tree" "4.2.0-rc.1"
-    "@aztec/native" "4.2.0-rc.1"
-    "@aztec/protocol-contracts" "4.2.0-rc.1"
-    "@aztec/stdlib" "4.2.0-rc.1"
-    "@aztec/telemetry-client" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0"
+    "@aztec/foundation" "4.2.0"
+    "@aztec/kv-store" "4.2.0"
+    "@aztec/merkle-tree" "4.2.0"
+    "@aztec/native" "4.2.0"
+    "@aztec/protocol-contracts" "4.2.0"
+    "@aztec/stdlib" "4.2.0"
+    "@aztec/telemetry-client" "4.2.0"
     tslib "^2.4.0"
     zod "^3.23.8"
 
@@ -1258,14 +1258,14 @@
     "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.10.0"
     "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.10.0"
 
-"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-49f460a/defi-wonderland-aztec-benchmark-4.2.0-rc.1-prerelease.49f460a.tgz":
-  version "4.2.0-rc.1-prerelease.49f460a"
-  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-49f460a/defi-wonderland-aztec-benchmark-4.2.0-rc.1-prerelease.49f460a.tgz#b238164eb4526269d856fbea1da2373511156b2f"
+"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-022ee63/defi-wonderland-aztec-benchmark-4.2.0-prerelease.022ee63.tgz":
+  version "4.2.0-prerelease.022ee63"
+  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-022ee63/defi-wonderland-aztec-benchmark-4.2.0-prerelease.022ee63.tgz#7eadacc1d39124ba5f809886cb5ab4736ce07ca6"
   dependencies:
     "@actions/core" "1.10.1"
     "@actions/exec" "1.1.1"
-    "@aztec/aztec.js" "4.2.0-rc.1"
-    "@aztec/wallets" "4.2.0-rc.1"
+    "@aztec/aztec.js" "4.2.0"
+    "@aztec/wallets" "4.2.0"
     "@iarna/toml" "2.2.5"
     "@types/node" "22.15.3"
     commander "13.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,59 +636,59 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz#f1137f56209ccc69c15f826242cbf37f828617dd"
   integrity sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==
 
-"@aztec/accounts@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-4.0.0-devnet.2-patch.1.tgz#18f6aad989fa49c724ef71d65933639a1ab74def"
-  integrity sha512-1zylLQOQjWK6/heWo2c2y+VKee+E5fFWptk/x8mxZFD5F8Z2jcw82TGN1keKp38V7qk0K8jROCYq/QCEZy3SKg==
+"@aztec/accounts@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-4.2.0-nightly.20260414.tgz#d73b2bfec1663333bb54781f1e4fbdbc72215fa0"
+  integrity sha512-e1w8wyd/SFAtoc6wVgxmu6Ij3l11rQQ9lJ3+LWjAF/4mGi5RACJ718ucJjSOGjhuqwThFjXCeZEiOpc4sEi6oQ==
   dependencies:
-    "@aztec/aztec.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/entrypoints" "4.0.0-devnet.2-patch.1"
-    "@aztec/ethereum" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/aztec.js" "4.2.0-nightly.20260414"
+    "@aztec/entrypoints" "4.2.0-nightly.20260414"
+    "@aztec/ethereum" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-4.0.0-devnet.2-patch.1.tgz#b4d1d9d9e4e24e0ba578b3a0765c8e11def7116e"
-  integrity sha512-tyaKVxp/Ba2FqTtPrM0u0j8ravdqWIggKtCxO+yusyg3sV/dZGa44BFoqrPX3pXPVITrcQGgRfqhOA13hNcc/Q==
+"@aztec/aztec.js@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-4.2.0-nightly.20260414.tgz#fecdbc538256c16b5901b179c5de80929a25e05c"
+  integrity sha512-eNbNHWIbE/lf9Pf6V3Wv7jfSuQceyfKbi3KciwigKYv6jKuvvq4Hn8veEy/Sd+SbZ0CMePWF4N2lH8X4AqPdfg==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/entrypoints" "4.0.0-devnet.2-patch.1"
-    "@aztec/ethereum" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/l1-artifacts" "4.0.0-devnet.2-patch.1"
-    "@aztec/protocol-contracts" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
-    axios "^1.12.0"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/entrypoints" "4.2.0-nightly.20260414"
+    "@aztec/ethereum" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/l1-artifacts" "4.2.0-nightly.20260414"
+    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    axios "^1.13.5"
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-4.0.0-devnet.2-patch.1.tgz#3b9bf7ebd0229fca6f2fe056fdf3c4cdae1c8d45"
-  integrity sha512-7jVwLQFWuIcbeev4jxAYvcm71RH7wm/mXc3tEt5X90QAvhvDOSqNOMQal7wr2Ars8h6OTvx45S4qFkITiJyLAA==
+"@aztec/bb-prover@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-4.2.0-nightly.20260414.tgz#0ca7dd24e2855ba7a2ec442b6ec63e7c5759ad8a"
+  integrity sha512-xFg0W7M0smlo4nsfoY+O979BfO5Bo4w50MlGyMudmEtiP78WcAsiKgGHlXZSIGa3P+9ftNRGT3wSlCo/T8iEzA==
   dependencies:
-    "@aztec/bb.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-noirc_abi" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-protocol-circuits-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/simulator" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
-    "@aztec/telemetry-client" "4.0.0-devnet.2-patch.1"
-    "@aztec/world-state" "4.0.0-devnet.2-patch.1"
+    "@aztec/bb.js" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
+    "@aztec/noir-protocol-circuits-types" "4.2.0-nightly.20260414"
+    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    "@aztec/simulator" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/telemetry-client" "4.2.0-nightly.20260414"
+    "@aztec/world-state" "4.2.0-nightly.20260414"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-4.0.0-devnet.2-patch.1.tgz#4caebd7590d2aaaba229a114c10e2b39f5259d55"
-  integrity sha512-SEOidi9kKFSE+DGA4w9h+PPJwXGXZ8VzG0xgrZgmx9cWFZMW7BW6k2kqkrmcd1n4YXrDYAztuLacw5oDvebuzg==
+"@aztec/bb.js@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-4.2.0-nightly.20260414.tgz#c6acdaa23cec0a159af8cbb19572535e5a666f07"
+  integrity sha512-D1uNCUxORq6EB2Xbz/5b4KRwGoOkIUTiumiMID4BRqktFpgxiF1mO7L70QuQHof+abJtZ1/aw8ChzbZl1m0yYA==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -697,54 +697,54 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-4.0.0-devnet.2-patch.1.tgz#ebaaa39f99e2b03cc5051690d325971793dfbde6"
-  integrity sha512-UxjqZSUd/B+puRp1hOYcrymsvSgMt+qFijwm6ygQtsnntb5+IJ35TYFGWXPEgvQnE5T0/+nIEJqwc2NvOlohcA==
+"@aztec/blob-lib@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-4.2.0-nightly.20260414.tgz#b3d77cae68e84b95c8cd7ec640176e70daa9e168"
+  integrity sha512-JlOFeE7TvlATuFaT9fb9KJoCLoz6tC205llzreFJj0IupcfX3EyX0xPs9wPulEoYJk6f2GiJuV3utGxbZbEbqg==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-4.0.0-devnet.2-patch.1.tgz#b7afe10628e92406c2b46147cfaa258df57d9b47"
-  integrity sha512-gzhHfqo4fRrYkB++0jJVGdXsKFBRQCmxQRJe+4fFRT7utarK12Kfgt99WYwhTUBR5fpxrz8xp8iLuF1qHJNAOQ==
+"@aztec/builder@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-4.2.0-nightly.20260414.tgz#a940307043d61746ba34bdda54ea0f1f046b5683"
+  integrity sha512-Wq2eSi6BL0k0nTf7GSgWXthUjF9MlFoEFIFjLmNP1ro+NvYjI/u+/pw60MtIPX4iBUFG2hn09+hFkbBCtNPtpw==
   dependencies:
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     commander "^12.1.0"
 
-"@aztec/constants@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-4.0.0-devnet.2-patch.1.tgz#42c12878146347b972b4fc40082cc0ca1b65f53b"
-  integrity sha512-rVM0ATvof5Ve4GHGbnvOvJ468CCeYVPrfLGvLs9dv567EHU7Z78y3P4vXm8JsW1pqXXcldqn2f9591R7dKMYHg==
+"@aztec/constants@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-4.2.0-nightly.20260414.tgz#5e5911027ca3904cef1a179e1d771a5a2e8ccd52"
+  integrity sha512-0+eOwMxE7wbvJ7tR3lGLAz4u8TSM7+dnuDv7EI72wrLz3EYV/LjPQD1MT9RcJxu7+YS4BQRiIiem6yfVd7R4XA==
   dependencies:
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-4.0.0-devnet.2-patch.1.tgz#e826a124d471954dfd04e9b5e788a20c80fce1c2"
-  integrity sha512-BqmKOuvMmWjL1MQFLIQUiCN9LBfqyFvOqFzLhxqnhQsKmjRMjmOFra5OBQMjmi04P7a1nIg45UgV+q41CoC/ag==
+"@aztec/entrypoints@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-4.2.0-nightly.20260414.tgz#2e4bbe6221967ad922a406376b4435c040f47997"
+  integrity sha512-yc0gX+At6QOl7gg8lb0cJ+ul/aN9KL0NOs39Nf8GTVT2B2qCSoYL2VZLnnLv+CCXcVtnrdyN3LGv+9GqTiyedQ==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/protocol-contracts" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/ethereum@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-4.0.0-devnet.2-patch.1.tgz#796a27822324ad6611c6b5932549d3689df65aef"
-  integrity sha512-MqdZBa3V/b8X80aVRa26V5yxo8gWWcSPfG7r4EaMQ2otA7t8MHRLJffN1TNwkYqJPCBuLiZpVGYM2gQw1qmx/A==
+"@aztec/ethereum@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-4.2.0-nightly.20260414.tgz#0f19a19ffe7d2a6f4157eadedc22a49339106bac"
+  integrity sha512-sQVZGilBsJ5dALHZNUIDHYbW32rgBCo4lrdezdKajCUCukgYhGVQ/1XHcSwKr167eJDXc/YpkthdyvjehrpJZQ==
   dependencies:
-    "@aztec/blob-lib" "4.0.0-devnet.2-patch.1"
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/l1-artifacts" "4.0.0-devnet.2-patch.1"
+    "@aztec/blob-lib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/l1-artifacts" "4.2.0-nightly.20260414"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
@@ -753,12 +753,12 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-4.0.0-devnet.2-patch.1.tgz#670df4ddb5289d5f684e25261adc7b8aa86e2eae"
-  integrity sha512-s61AqiRhueNVqvCh+11QY/pWExmBtMYq1aD0nXt7ocpkbVEjbuP/1AzmIej5UDcUnC2l+2Z89dDiz4uXDd8pyQ==
+"@aztec/foundation@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-4.2.0-nightly.20260414.tgz#3084846112367da720a0e1b002a97460e0635970"
+  integrity sha512-xfXwr5Y/OxryUxY1cv35JK7/j6xIMoOrM8f9b1wIs92Wj8m6z/JBX1RJZr6gzEI5XZga11hXLgPG2Y6O3DjgJw==
   dependencies:
-    "@aztec/bb.js" "4.0.0-devnet.2-patch.1"
+    "@aztec/bb.js" "4.2.0-nightly.20260414"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
     "@noble/hashes" "^1.6.1"
@@ -781,140 +781,140 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-4.0.0-devnet.2-patch.1.tgz#4f1f942641aac7234b98f6d32077bf453bfc09ea"
-  integrity sha512-UNMWNrfOCrRa9zKeHDOVN0YXUGhgMU477foTPcZ5YvAtYTJlQ8znbJ6xiaMWEJEroDIl5aorGlLIdxY3sseKRw==
+"@aztec/key-store@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-4.2.0-nightly.20260414.tgz#0894787c192dcf106dd47c2900c3714ca663bdbe"
+  integrity sha512-r9uvWL3/d65CZdR+OOM5SwHcf+MaLFLczYvc6KDCK0LFZHjVOudER5lxFp0DzDUVok5BfubvO2R83Hecf1yicQ==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/kv-store" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/kv-store" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     tslib "^2.4.0"
 
-"@aztec/kv-store@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-4.0.0-devnet.2-patch.1.tgz#16afe1fcd60d835f77e8583e9d998bd992f6956c"
-  integrity sha512-z4IyhmseSFnP2shRtf6wmQxxMBwr7atdUnpYGP+y2L6LWtTvQ4wnHNY7wx/nSFcJ79bkyJF+j5DxJPCgcxDk7g==
+"@aztec/kv-store@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-4.2.0-nightly.20260414.tgz#1a34e521c044c6f1681f85fa2aa7dcfe9cfdadae"
+  integrity sha512-lmpRMrFgjcWGdmqcdshSuWOqW0LbdJhyXw6KlwF2c4IV5+E8fLGjNAsGXhZefA5EEOd58x3QYWObDgKhMa9aYw==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/ethereum" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/native" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/ethereum" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/native" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-4.0.0-devnet.2-patch.1.tgz#d5d5e5c79b38d21047bb7100072dc37d4cba2ffe"
-  integrity sha512-Tj7BtWas0Z2zP390hLrZGBgvvmWJ33YIxwb+m8M/qdeAQNhszn3KFX0dPRH6kNiuBl/iikxLhjL+C5R1eLkgnA==
+"@aztec/l1-artifacts@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-4.2.0-nightly.20260414.tgz#51a618ca36f3d5eee411a67395c077fde36a94e5"
+  integrity sha512-3d6I9ICwdU4lznv2ZJcHq/wUa0E2Ju6uitpZPRclRNlC2XIoY3lqdV7DA75LBD2LhkmfhTfoACkjI2VOoKwrsg==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-4.0.0-devnet.2-patch.1.tgz#a4a1105408abb3b86defb3f3bb85e23fd497c949"
-  integrity sha512-vmKwpOeKSE72Uj8XgOqdjys9jyEEfcJWIoVG2c/b/1hVBsp3+nARWIB73ksqjzfSbxSq3INZMYYjEWTiFfDbDA==
+"@aztec/merkle-tree@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-4.2.0-nightly.20260414.tgz#f09ad023a1201541e69b304d62b50efd48d97084"
+  integrity sha512-qegyQNop6uC3Cf1JCmvpwNsM0KBQqJrT1uqX2APAeFrRXRwsBZBPqKHKeQ6gDcZXtKXWkth70alocqv2wVH66g==
   dependencies:
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/kv-store" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/kv-store" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-4.0.0-devnet.2-patch.1.tgz#055c6530bf5121dc74a40d7cff3376f230f5e0b1"
-  integrity sha512-ljlDodg+QDpJjdobfu//6sb8J2crGNUmZfEDBQtq1FU/3WZGDEVw+Dpie3IM+U92Ca6nhe1/xCEy1GTacpuFpg==
+"@aztec/native@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-4.2.0-nightly.20260414.tgz#8a775fe9ada3fef47a31362dab7dd3d4d5354953"
+  integrity sha512-8wyhC74W0q7XA872y29gchsmIgICMjoisQMqr/MtzRHPl5yIRoKfuIAF+xyVZef/X/upJNrBMl8n5GIiNo+xrw==
   dependencies:
-    "@aztec/bb.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
+    "@aztec/bb.js" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-4.0.0-devnet.2-patch.1.tgz#3ac027dbdc465e1d5180bcb9d0004f0c58187e18"
-  integrity sha512-wXi4cqLN/5jENfJtHTg5MZSBoU1/OPbAXozWmpi6yP26rBmVQY7c4Fq0D7HwxoGgBoYfflweszM9ZEhKS8Srlg==
+"@aztec/noir-acvm_js@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-4.2.0-nightly.20260414.tgz#f36f047ce44db376c9ef67777e9a7a5d49c2f79d"
+  integrity sha512-45wpj/GoNTouw8j+Zrm4F6QhnoxnPVvI6/akI8uYxC+IJMTq69suXA4+ONr73pe27tB869T2aTcGY3pi7FE8lw==
 
-"@aztec/noir-contracts.js@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-4.0.0-devnet.2-patch.1.tgz#acbd0b4997115506da395c0a4200415678dea73e"
-  integrity sha512-BMyF++ifcnwd6ydcYJ9EmCvA1MEr0XkoAJhVImqUkYGQmGo9qXFlspQ908pz4nsfJ6Id4bz3DlReJFiuufvQAQ==
+"@aztec/noir-contracts.js@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-4.2.0-nightly.20260414.tgz#c6858665c6af853b5528d6527622482c057ee48c"
+  integrity sha512-L+K4QPJ3xCBnkdl6Oe1XPwdyuYZ0T5Io94RyQWE81Z9vZM9LjUI3hhE6/ZzDSln+4Q718gX+6M7MYc9yKdn3JQ==
   dependencies:
-    "@aztec/aztec.js" "4.0.0-devnet.2-patch.1"
+    "@aztec/aztec.js" "4.2.0-nightly.20260414"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-4.0.0-devnet.2-patch.1.tgz#1e1419a7e58de6b3e0b12666de5325439dc7f4d7"
-  integrity sha512-E0mHd74YwJ6ZrBk64zjdN37DywavGMoRQZicDdc1CRIu/rKU94de+KJbH7xH+fIDQ1H23uEV555uajNo36zhDA==
+"@aztec/noir-noir_codegen@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-4.2.0-nightly.20260414.tgz#6d469a1b4e84576cc81b8f590a80012db5360de5"
+  integrity sha512-T/Pznn+bjmhIkg4SY6jmGoco25l8mJH+YQQHjNU0ju3zr0VglPGuHsS6gvh8Z6TAgeJePKzVnps+PeoWlcYISg==
   dependencies:
-    "@aztec/noir-types" "4.0.0-devnet.2-patch.1"
-    glob "^13.0.0"
+    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    glob "^13.0.6"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-4.0.0-devnet.2-patch.1.tgz#26fe7a639d0fe2d7c03828fc0e07db7bf7f9f338"
-  integrity sha512-9cxLL0BZi0Jw7VT8OK9qYbH7Z7tdz0TIfDHDfiFsXSmtABflAN7XMZ1DwJnwIqPDoTVTBTev99Y9Wh01zyBbWg==
+"@aztec/noir-noirc_abi@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-4.2.0-nightly.20260414.tgz#7b35031bd580aef9ff38bacc845b6319f29674f7"
+  integrity sha512-0N95PnVbTSqaVI6EWU8lxfSyJdd3CZBEPwPtp3RfmwmbPe4pI6mC4zUgoRjFWfWINA5LFO3wQ+PH2lT0mNxCEA==
   dependencies:
-    "@aztec/noir-types" "4.0.0-devnet.2-patch.1"
+    "@aztec/noir-types" "4.2.0-nightly.20260414"
 
-"@aztec/noir-protocol-circuits-types@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-4.0.0-devnet.2-patch.1.tgz#e77c3569d82503b4a57ae7d1a79ec2ddabc81ccd"
-  integrity sha512-rzMyITJvLprXu+TXGSUeisrbl5A1cVZGui5KlaPo+FrqL+GKbBypvqicMgGnirHQ5uDbYH2j/W9IYnlYvwDhoA==
+"@aztec/noir-protocol-circuits-types@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-4.2.0-nightly.20260414.tgz#16bae9af81d9e376e15602c45100ed93e7ef38a0"
+  integrity sha512-pk8C+C8/2AWAoSvN5VUfR1r+poTuQSyaeD8amMqiL7c6r6+Z5APUkJ+QjuGPId04xgXfMLlYq1cKbyEXisPaWw==
   dependencies:
-    "@aztec/blob-lib" "4.0.0-devnet.2-patch.1"
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-acvm_js" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-noir_codegen" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-noirc_abi" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/blob-lib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/noir-acvm_js" "4.2.0-nightly.20260414"
+    "@aztec/noir-noir_codegen" "4.2.0-nightly.20260414"
+    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
+    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-4.0.0-devnet.2-patch.1.tgz#080ee9514c85bd0b8698b3a5321646449b46ad22"
-  integrity sha512-W6bY7YyYXNYYOt/xbIfiZEh8k+pDraxmK1UiU67JO+UYMz4cEru7utJ0vhJ7zbBhvZxRNP9Y59TjfKy5vBYyag==
+"@aztec/noir-types@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-4.2.0-nightly.20260414.tgz#bacbd041d9eaa9ced483bfa9c0833411251ac3a2"
+  integrity sha512-jmemYutCgdatPkvDBnPat4AyQsmcB6YVRpjDawufcRWI71a9FICvTVKKZ6UyZJ+35wsDUJucMpwph0Fczxo26g==
 
-"@aztec/protocol-contracts@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-4.0.0-devnet.2-patch.1.tgz#f15bf67904e005b3658896923a6b8a254afa1b29"
-  integrity sha512-7gcHZvqD2RgdtSp28KWS3Xsr7PbiYNj1GP3tcHtmCzCCFJnTCiruNdDWpW1Z4zojlcAWlddUG95enrjTliI8ZA==
+"@aztec/protocol-contracts@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-4.2.0-nightly.20260414.tgz#71df734a9c8ceb1e66fd23518a70b986cacaff9e"
+  integrity sha512-mDWUL09FpUdP2ndc6YZBqlOrthKdcxcGaeZg+5NRcx3x4SVGRMEdFlL+EhCDlfV/Rt9W81iKqHqEB6fFUo8a3A==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-4.0.0-devnet.2-patch.1.tgz#fb554f1d2ef29aa49a2767c30ffb7a2b0ef2294f"
-  integrity sha512-AJcBsKQhYxitn8QM5HN1Rwoz7D5dCuYh2U5T6VIFRyGC4c0hp+lFoY20/5D2rG04O2JdUx1cDJDhg2R7ZVw+vQ==
+"@aztec/pxe@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-4.2.0-nightly.20260414.tgz#1cc88da781f3eeac3d34b7ee75e25acf07b3fed9"
+  integrity sha512-7kgWXgcqjFooxSF0+q5hArek550PX0n3BfJrtq6K1d2QS//cLlmhXg8SaWhWXz6DGi3+7HfkGOhp9A0GcNf5GA==
   dependencies:
-    "@aztec/bb-prover" "4.0.0-devnet.2-patch.1"
-    "@aztec/bb.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/builder" "4.0.0-devnet.2-patch.1"
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/ethereum" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/key-store" "4.0.0-devnet.2-patch.1"
-    "@aztec/kv-store" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-protocol-circuits-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/protocol-contracts" "4.0.0-devnet.2-patch.1"
-    "@aztec/simulator" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/bb-prover" "4.2.0-nightly.20260414"
+    "@aztec/bb.js" "4.2.0-nightly.20260414"
+    "@aztec/builder" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/ethereum" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/key-store" "4.2.0-nightly.20260414"
+    "@aztec/kv-store" "4.2.0-nightly.20260414"
+    "@aztec/noir-protocol-circuits-types" "4.2.0-nightly.20260414"
+    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
+    "@aztec/simulator" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
@@ -922,42 +922,42 @@
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-4.0.0-devnet.2-patch.1.tgz#2cc70cf9af6f07b20379fc3b9f203ef10f69c9b0"
-  integrity sha512-etecxwltlKQ9vdSPtC1iByNcWrWfSLFQZeXviFpBV8Uj67v0H3nJ+86wgG9ivJ0yreWo+pgTKeX7GRyz+W/J6g==
+"@aztec/simulator@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-4.2.0-nightly.20260414.tgz#4a7262229f1d18fe0cac1357969516a27abbfaa2"
+  integrity sha512-LWsoPiI0sL7BIqKKsr7OJb2pqFq7d+i3y/CTyfrZbiwLgz3/bo6vefF8K/ge1E4UMg2hy8MFLB80cX3k9GEtMA==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/native" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-acvm_js" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-noirc_abi" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-protocol-circuits-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-types" "4.0.0-devnet.2-patch.1"
-    "@aztec/protocol-contracts" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
-    "@aztec/telemetry-client" "4.0.0-devnet.2-patch.1"
-    "@aztec/world-state" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/native" "4.2.0-nightly.20260414"
+    "@aztec/noir-acvm_js" "4.2.0-nightly.20260414"
+    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
+    "@aztec/noir-protocol-circuits-types" "4.2.0-nightly.20260414"
+    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/telemetry-client" "4.2.0-nightly.20260414"
+    "@aztec/world-state" "4.2.0-nightly.20260414"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-4.0.0-devnet.2-patch.1.tgz#429e9bf8ed4f2e9baf8d6e23dca41eb85b879176"
-  integrity sha512-pgNAoejMOw7Xv+q+TkQScZ70D4eQxh5qUMyrwy1gYR3NXuHZahqKwg87eWP1JvqIitWD2n0jW2w49hU3rHmErg==
+"@aztec/stdlib@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-4.2.0-nightly.20260414.tgz#9391104518e964d20fa8005551aa03f9b68447a0"
+  integrity sha512-jmhkgiwW3bQibdR6Isk8hK/MfQ30CjSNGPsiYNKK2E87LIAUg6Eq2EkGZsMfIaAfQZjTUxXUns37OkXYeiriLw==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/blob-lib" "4.0.0-devnet.2-patch.1"
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/ethereum" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/l1-artifacts" "4.0.0-devnet.2-patch.1"
-    "@aztec/noir-noirc_abi" "4.0.0-devnet.2-patch.1"
-    "@aztec/validator-ha-signer" "4.0.0-devnet.2-patch.1"
+    "@aztec/bb.js" "4.2.0-nightly.20260414"
+    "@aztec/blob-lib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/ethereum" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/l1-artifacts" "4.2.0-nightly.20260414"
+    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
+    "@aztec/validator-ha-signer" "4.2.0-nightly.20260414"
     "@google-cloud/storage" "^7.15.0"
-    axios "^1.12.0"
+    axios "^1.13.5"
     json-stringify-deterministic "1.0.12"
     lodash.chunk "^4.2.0"
     lodash.isequal "^4.5.0"
@@ -969,13 +969,13 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-4.0.0-devnet.2-patch.1.tgz#e5c601c5eeb766ce5d87d495b9b080c0c9290d65"
-  integrity sha512-hrLHKcUYP9p4/5OzQxYhD9fUrywalOn/WwxladNICc4AoAkirbvS8cC6I03JfuQXVe5fR6GhEpr3J2nI7/dVtA==
+"@aztec/telemetry-client@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-4.2.0-nightly.20260414.tgz#4e0f634c5a26b976457a0c7968bafe757d382719"
+  integrity sha512-1dqezUnuewv3LgRjgWaFIDqtf8pFvTsWp1Dps0JtaF+/y1ty4bS9C5Obqdki4UdeqIaZoiIghm6dEjYl2VyqlQ==
   dependencies:
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -993,58 +993,58 @@
     prom-client "^15.1.3"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/validator-ha-signer@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/validator-ha-signer/-/validator-ha-signer-4.0.0-devnet.2-patch.1.tgz#c81ea2d08d5d60870e36cd20fe3b5a9cfafe3074"
-  integrity sha512-vp9dMqK5RzDzpKwnXSb99XNosOExDBUsjCAFDPoRz5RJZlEvgHOptPKB45YiQlHkWxZGLXKQil26DP+LcxALeA==
+"@aztec/validator-ha-signer@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/validator-ha-signer/-/validator-ha-signer-4.2.0-nightly.20260414.tgz#74034448580ef191707f5496f253e744ef5761ac"
+  integrity sha512-VT0XeD8Xr2030IR1fRvrQ+duWHNODh4YEWDqwkwbwpceRC88Ib5OyONP43Z4rj7D4sNokNkQJz44pf3qGaO3gw==
   dependencies:
-    "@aztec/ethereum" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
+    "@aztec/ethereum" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
     node-pg-migrate "^8.0.4"
     pg "^8.11.3"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/wallet-sdk@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-4.0.0-devnet.2-patch.1.tgz#9d8dcb3828c8de8378a54b22c17bfbc36f9e8b41"
-  integrity sha512-Hmp/Dz/Pt0c8+h231LRTwUAt7MiKa94q3KTsTQir9xIz+ZyJKTnvrWBIzgCbLAUZQy/XpOSWrHsLk99FOX2EKg==
+"@aztec/wallet-sdk@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-4.2.0-nightly.20260414.tgz#3bd88d3ff66a1a4a1c83afef5566cff7ad11061f"
+  integrity sha512-g4ARmko/g9I6qyTiQZ7YcTG5v3w66OdpUbgQBDYM9xvUHueAZ6A1kAFZ7DmO5lJeYWv9CANzzllOX3AlEKvfxQ==
   dependencies:
-    "@aztec/aztec.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/entrypoints" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/pxe" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
+    "@aztec/aztec.js" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/entrypoints" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/pxe" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
 
-"@aztec/wallets@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/wallets/-/wallets-4.0.0-devnet.2-patch.1.tgz#af858fd4673279fe84758e41fa9198caf04c397b"
-  integrity sha512-g34ULDFovIVmXv2VpkydAFkmp8mmDkHd94/+8BFwKzieg7omlIwQqSvGaClki7nxWBeLJ6r71OD8PK8PV54qpQ==
+"@aztec/wallets@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/wallets/-/wallets-4.2.0-nightly.20260414.tgz#a54d74ada81480add7e32ed38a5d418cc29555e0"
+  integrity sha512-lyagiFEg1o+zN4705eQzwe/GjsOC6eV28pV4LIKgGlTxY7mp7l2mYL7Xt6CmStY1pnpMiUxCobKXWHGsuwhT/Q==
   dependencies:
-    "@aztec/accounts" "4.0.0-devnet.2-patch.1"
-    "@aztec/aztec.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/entrypoints" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/kv-store" "4.0.0-devnet.2-patch.1"
-    "@aztec/protocol-contracts" "4.0.0-devnet.2-patch.1"
-    "@aztec/pxe" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
-    "@aztec/wallet-sdk" "4.0.0-devnet.2-patch.1"
+    "@aztec/accounts" "4.2.0-nightly.20260414"
+    "@aztec/aztec.js" "4.2.0-nightly.20260414"
+    "@aztec/entrypoints" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/kv-store" "4.2.0-nightly.20260414"
+    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
+    "@aztec/pxe" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/wallet-sdk" "4.2.0-nightly.20260414"
 
-"@aztec/world-state@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-4.0.0-devnet.2-patch.1.tgz#9c3c7c02e58f6e1b156e930a1292e7d49826e4ff"
-  integrity sha512-3NqI9Y8rhWp4pWD5qTO3QGoXTIajuTwoz3Up2/Sif7q/blBfnqfU5fiImiZgXER7waxDtJkBzeji02KhJip0uA==
+"@aztec/world-state@4.2.0-nightly.20260414":
+  version "4.2.0-nightly.20260414"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-4.2.0-nightly.20260414.tgz#9a3f870e22a52f3e4095cdf72a045858160d84c5"
+  integrity sha512-7xpFo9/YirAez9cRO7FMcLVMGAtYb7Z3TzvzE6lgqdZsetrP1agimPqtDS3gtLYNa8pjdg7jHiy2Vq9Tq4TQdQ==
   dependencies:
-    "@aztec/constants" "4.0.0-devnet.2-patch.1"
-    "@aztec/foundation" "4.0.0-devnet.2-patch.1"
-    "@aztec/kv-store" "4.0.0-devnet.2-patch.1"
-    "@aztec/merkle-tree" "4.0.0-devnet.2-patch.1"
-    "@aztec/native" "4.0.0-devnet.2-patch.1"
-    "@aztec/protocol-contracts" "4.0.0-devnet.2-patch.1"
-    "@aztec/stdlib" "4.0.0-devnet.2-patch.1"
-    "@aztec/telemetry-client" "4.0.0-devnet.2-patch.1"
+    "@aztec/constants" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/kv-store" "4.2.0-nightly.20260414"
+    "@aztec/merkle-tree" "4.2.0-nightly.20260414"
+    "@aztec/native" "4.2.0-nightly.20260414"
+    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
+    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/telemetry-client" "4.2.0-nightly.20260414"
     tslib "^2.4.0"
     zod "^3.23.8"
 
@@ -1258,15 +1258,14 @@
     "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.10.0"
     "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.10.0"
 
-"@defi-wonderland/aztec-benchmark@4.0.0-devnet.2-patch.1":
-  version "4.0.0-devnet.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/aztec-benchmark/-/aztec-benchmark-4.0.0-devnet.2-patch.1.tgz#a291dad485bdc38ca30a087db5e7405eb729388d"
-  integrity sha512-++6E0FLaUUVYHGIYw+uvgx2xYVU0fkgFzwW0w3EJintvw8KsiU30pe6kk2/QGbtfbe08BdiCNNawfDrOU3oFiw==
+"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-c922ff4/defi-wonderland-aztec-benchmark-4.2.0-nightly.20260414-prerelease.c922ff4.tgz":
+  version "4.2.0-nightly.20260414-prerelease.c922ff4"
+  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-c922ff4/defi-wonderland-aztec-benchmark-4.2.0-nightly.20260414-prerelease.c922ff4.tgz#7fba2bf548d976f04c54b478296085b08d50bcc8"
   dependencies:
     "@actions/core" "1.10.1"
     "@actions/exec" "1.1.1"
-    "@aztec/aztec.js" "4.0.0-devnet.2-patch.1"
-    "@aztec/wallets" "4.0.0-devnet.2-patch.1"
+    "@aztec/aztec.js" "4.2.0-nightly.20260414"
+    "@aztec/wallets" "4.2.0-nightly.20260414"
     "@iarna/toml" "2.2.5"
     "@types/node" "22.15.3"
     commander "13.1.0"
@@ -3042,14 +3041,19 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
-axios@^1.12.0:
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.4.tgz#15d109a4817fb82f73aea910d41a2c85606076bc"
-  integrity sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==
+axios@^1.13.5:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
@@ -3075,6 +3079,13 @@ bowser@^2.11.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.13.1.tgz#5a4c652de1d002f847dd011819f5fc729f308a7e"
   integrity sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==
+
+brace-expansion@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -3764,10 +3775,15 @@ find-replace@^3.0.0:
   dependencies:
     array-back "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
+follow-redirects@^1.15.11:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 foreground-child@^3.3.1:
   version "3.3.1"
@@ -3789,7 +3805,7 @@ form-data@^2.5.5:
     mime-types "^2.1.35"
     safe-buffer "^5.2.1"
 
-form-data@^4.0.4:
+form-data@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -3900,14 +3916,14 @@ git-raw-commits@^4.0.0:
     meow "^12.0.1"
     split2 "^4.0.0"
 
-glob@^13.0.0:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.1.tgz#c59a2500c9a5f1ab9cdd370217ced63c2aa81e60"
-  integrity sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==
+glob@^13.0.6:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
   dependencies:
-    minimatch "^10.1.2"
-    minipass "^7.1.2"
-    path-scurry "^2.0.0"
+    minimatch "^10.2.2"
+    minipass "^7.1.3"
+    path-scurry "^2.0.2"
 
 glob@~11.1.0:
   version "11.1.0"
@@ -4597,12 +4613,19 @@ minimalistic-assert@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@^10.1.1, minimatch@^10.1.2:
+minimatch@^10.1.1:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.1.2.tgz#6c3f289f9de66d628fa3feb1842804396a43d81c"
   integrity sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==
   dependencies:
     "@isaacs/brace-expansion" "^5.0.1"
+
+minimatch@^10.2.2:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
 
 minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
@@ -4613,6 +4636,11 @@ minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
+minipass@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -4828,6 +4856,14 @@ path-scurry@^2.0.0:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
 
+path-scurry@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
+
 path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
@@ -5036,10 +5072,10 @@ protobufjs@^7.3.0:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pump@^3.0.0:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,59 +636,59 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz#f1137f56209ccc69c15f826242cbf37f828617dd"
   integrity sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==
 
-"@aztec/accounts@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-4.2.0-nightly.20260414.tgz#d73b2bfec1663333bb54781f1e4fbdbc72215fa0"
-  integrity sha512-e1w8wyd/SFAtoc6wVgxmu6Ij3l11rQQ9lJ3+LWjAF/4mGi5RACJ718ucJjSOGjhuqwThFjXCeZEiOpc4sEi6oQ==
+"@aztec/accounts@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-4.2.0-rc.1.tgz#2dcd215578af1888ab65254769a88d08d22873f4"
+  integrity sha512-vsKpXUzJn6GpmMK2V1XyjyDs2qpE1dvvngQKpNMGSBVwdRm9O/vhu7C3J5UEvzdHbMDNJAUkK8d5RMFhmezKsg==
   dependencies:
-    "@aztec/aztec.js" "4.2.0-nightly.20260414"
-    "@aztec/entrypoints" "4.2.0-nightly.20260414"
-    "@aztec/ethereum" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/aztec.js" "4.2.0-rc.1"
+    "@aztec/entrypoints" "4.2.0-rc.1"
+    "@aztec/ethereum" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-4.2.0-nightly.20260414.tgz#fecdbc538256c16b5901b179c5de80929a25e05c"
-  integrity sha512-eNbNHWIbE/lf9Pf6V3Wv7jfSuQceyfKbi3KciwigKYv6jKuvvq4Hn8veEy/Sd+SbZ0CMePWF4N2lH8X4AqPdfg==
+"@aztec/aztec.js@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-4.2.0-rc.1.tgz#0e4e499d265a722434ff9564b7c950d5f3b5be14"
+  integrity sha512-PxkQMvVlFzwJVMDuhHqJD6ItlguIbYFn8dOmZw6R5kXJdLLI6WXtBZgo4KR06qbkAKaawkEFHy2YSmxLUOw47Q==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/entrypoints" "4.2.0-nightly.20260414"
-    "@aztec/ethereum" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/l1-artifacts" "4.2.0-nightly.20260414"
-    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/entrypoints" "4.2.0-rc.1"
+    "@aztec/ethereum" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/l1-artifacts" "4.2.0-rc.1"
+    "@aztec/protocol-contracts" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     axios "^1.13.5"
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-4.2.0-nightly.20260414.tgz#0ca7dd24e2855ba7a2ec442b6ec63e7c5759ad8a"
-  integrity sha512-xFg0W7M0smlo4nsfoY+O979BfO5Bo4w50MlGyMudmEtiP78WcAsiKgGHlXZSIGa3P+9ftNRGT3wSlCo/T8iEzA==
+"@aztec/bb-prover@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-4.2.0-rc.1.tgz#282b57dabb9b5a36d1647f8424b3e2e785549305"
+  integrity sha512-iCn+YQd5+ATR8OGznUDDxCTQJYjBlf+qH0P1F8S52YaCoAhpyEsueOoG7EfevAdg6vzGu5xZEc0s0mHdQK6R+A==
   dependencies:
-    "@aztec/bb.js" "4.2.0-nightly.20260414"
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
-    "@aztec/noir-protocol-circuits-types" "4.2.0-nightly.20260414"
-    "@aztec/noir-types" "4.2.0-nightly.20260414"
-    "@aztec/simulator" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
-    "@aztec/telemetry-client" "4.2.0-nightly.20260414"
-    "@aztec/world-state" "4.2.0-nightly.20260414"
+    "@aztec/bb.js" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
+    "@aztec/noir-protocol-circuits-types" "4.2.0-rc.1"
+    "@aztec/noir-types" "4.2.0-rc.1"
+    "@aztec/simulator" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/telemetry-client" "4.2.0-rc.1"
+    "@aztec/world-state" "4.2.0-rc.1"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-4.2.0-nightly.20260414.tgz#c6acdaa23cec0a159af8cbb19572535e5a666f07"
-  integrity sha512-D1uNCUxORq6EB2Xbz/5b4KRwGoOkIUTiumiMID4BRqktFpgxiF1mO7L70QuQHof+abJtZ1/aw8ChzbZl1m0yYA==
+"@aztec/bb.js@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-4.2.0-rc.1.tgz#3c43272147e9b6377fbe3b1e066cc662f26f88ad"
+  integrity sha512-K5Tp3SdHP9clJ1V6P2qDlt1y/bJSzF+w3kPA+vAfQdHtazSwoqG1FomO7swk3mOMFcQA7cqiwMlv203hAhh/mw==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -697,54 +697,54 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-4.2.0-nightly.20260414.tgz#b3d77cae68e84b95c8cd7ec640176e70daa9e168"
-  integrity sha512-JlOFeE7TvlATuFaT9fb9KJoCLoz6tC205llzreFJj0IupcfX3EyX0xPs9wPulEoYJk6f2GiJuV3utGxbZbEbqg==
+"@aztec/blob-lib@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-4.2.0-rc.1.tgz#0c34059f4b6e1fd41890f011a2df0659758e5765"
+  integrity sha512-qv6SeslnJQFFBPWdqgM15lTaAnNlhPiuCS34P6iKSM/ZYHAC3PbA1nZgrOZaS3E1O3yY6qCZJBVvnlEWv7uF7g==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-4.2.0-nightly.20260414.tgz#a940307043d61746ba34bdda54ea0f1f046b5683"
-  integrity sha512-Wq2eSi6BL0k0nTf7GSgWXthUjF9MlFoEFIFjLmNP1ro+NvYjI/u+/pw60MtIPX4iBUFG2hn09+hFkbBCtNPtpw==
+"@aztec/builder@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-4.2.0-rc.1.tgz#ac099a52c8b8f4229048a910ee492e2b843656c4"
+  integrity sha512-A36tSQ2zRbiHY0DwffdyYobVjb4U0nCi6Cvq/fvh/dgouKhsJOU0n9P7SRmCWGupm25ooeZvc4WEmh5XleUYDA==
   dependencies:
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     commander "^12.1.0"
 
-"@aztec/constants@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-4.2.0-nightly.20260414.tgz#5e5911027ca3904cef1a179e1d771a5a2e8ccd52"
-  integrity sha512-0+eOwMxE7wbvJ7tR3lGLAz4u8TSM7+dnuDv7EI72wrLz3EYV/LjPQD1MT9RcJxu7+YS4BQRiIiem6yfVd7R4XA==
+"@aztec/constants@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-4.2.0-rc.1.tgz#d5e358c85871858ed68bb7a27b5e0ee66ee57619"
+  integrity sha512-aAts5chSX451IV/XySEIjKLJNRPn/iUZELJmkjKTce1kRhi1PD5bFiHvnd/97Of6xsqRyyja4QuBdlJ2ihAepA==
   dependencies:
-    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-rc.1"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-4.2.0-nightly.20260414.tgz#2e4bbe6221967ad922a406376b4435c040f47997"
-  integrity sha512-yc0gX+At6QOl7gg8lb0cJ+ul/aN9KL0NOs39Nf8GTVT2B2qCSoYL2VZLnnLv+CCXcVtnrdyN3LGv+9GqTiyedQ==
+"@aztec/entrypoints@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-4.2.0-rc.1.tgz#584a5574fc1f8a2a11375e6c857409de8aa94595"
+  integrity sha512-LafdJUkJbD9TZ6fHcXQNVSJG3VnXADylsIXiJj6Kyso7F+U/RgEO2whTPilkkBYVuWvn2/zm3Rx1+IXL4+R8jw==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/protocol-contracts" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/ethereum@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-4.2.0-nightly.20260414.tgz#0f19a19ffe7d2a6f4157eadedc22a49339106bac"
-  integrity sha512-sQVZGilBsJ5dALHZNUIDHYbW32rgBCo4lrdezdKajCUCukgYhGVQ/1XHcSwKr167eJDXc/YpkthdyvjehrpJZQ==
+"@aztec/ethereum@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-4.2.0-rc.1.tgz#3643e7091a636a7c42c2b6db114e768c26e54531"
+  integrity sha512-EKE+hJyAx720j/DpGTahLhcUOgXZ/iN0vz37obvmoMyMeDQ+rdUqyrLCLipW5UY5dBZ9epzUiF56xJSuxgfnbQ==
   dependencies:
-    "@aztec/blob-lib" "4.2.0-nightly.20260414"
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/l1-artifacts" "4.2.0-nightly.20260414"
+    "@aztec/blob-lib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/l1-artifacts" "4.2.0-rc.1"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
@@ -753,12 +753,12 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-4.2.0-nightly.20260414.tgz#3084846112367da720a0e1b002a97460e0635970"
-  integrity sha512-xfXwr5Y/OxryUxY1cv35JK7/j6xIMoOrM8f9b1wIs92Wj8m6z/JBX1RJZr6gzEI5XZga11hXLgPG2Y6O3DjgJw==
+"@aztec/foundation@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-4.2.0-rc.1.tgz#c15206c3a0d178c9b2da0b55f7562ff1316a21dc"
+  integrity sha512-+RgkC0EZxuAD3EnNe3xljYR5hCJqHjQj7DegLs/anaL55vydcWLFaNaN+CgcGKHV1ldWpi3YNYV6Aw7ghoV/kQ==
   dependencies:
-    "@aztec/bb.js" "4.2.0-nightly.20260414"
+    "@aztec/bb.js" "4.2.0-rc.1"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
     "@noble/hashes" "^1.6.1"
@@ -781,140 +781,140 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-4.2.0-nightly.20260414.tgz#0894787c192dcf106dd47c2900c3714ca663bdbe"
-  integrity sha512-r9uvWL3/d65CZdR+OOM5SwHcf+MaLFLczYvc6KDCK0LFZHjVOudER5lxFp0DzDUVok5BfubvO2R83Hecf1yicQ==
+"@aztec/key-store@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-4.2.0-rc.1.tgz#9d8ca3fd061be38dd03d65230ec3bcb14f58f075"
+  integrity sha512-01bXCld4reQVNWIlHeHpNPonCk45iZSeRVDP0J9geCjEX8PNgUo33oX6wv1HdCQ4bZ09Cqz48utG/5HvaWx3aA==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/kv-store" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/kv-store" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     tslib "^2.4.0"
 
-"@aztec/kv-store@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-4.2.0-nightly.20260414.tgz#1a34e521c044c6f1681f85fa2aa7dcfe9cfdadae"
-  integrity sha512-lmpRMrFgjcWGdmqcdshSuWOqW0LbdJhyXw6KlwF2c4IV5+E8fLGjNAsGXhZefA5EEOd58x3QYWObDgKhMa9aYw==
+"@aztec/kv-store@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-4.2.0-rc.1.tgz#61a427e5c5f96ea429572529220522c12eefd797"
+  integrity sha512-iEK7+ltXSRp/V5gNz/J9Mx7AOkYiNwoFGwmSn1E/ieghkta6IvYeu/QmwLHvrMXSGBQFirB73L8eY8ciGFsxYQ==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/ethereum" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/native" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/ethereum" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/native" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-4.2.0-nightly.20260414.tgz#51a618ca36f3d5eee411a67395c077fde36a94e5"
-  integrity sha512-3d6I9ICwdU4lznv2ZJcHq/wUa0E2Ju6uitpZPRclRNlC2XIoY3lqdV7DA75LBD2LhkmfhTfoACkjI2VOoKwrsg==
+"@aztec/l1-artifacts@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-4.2.0-rc.1.tgz#ecb9a83b6d75c8d68125c90699abb48d6d021497"
+  integrity sha512-F0xP6Vq0/mpFHQ4rLOqVaBcdfBe7LYm0zq1KUxNqV6FIWOTXHzWuCdCn55jG3UE70DE2y1QEZqWwJo+v5ZdQlg==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-4.2.0-nightly.20260414.tgz#f09ad023a1201541e69b304d62b50efd48d97084"
-  integrity sha512-qegyQNop6uC3Cf1JCmvpwNsM0KBQqJrT1uqX2APAeFrRXRwsBZBPqKHKeQ6gDcZXtKXWkth70alocqv2wVH66g==
+"@aztec/merkle-tree@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-4.2.0-rc.1.tgz#06c3680a4dbbacb03bec9a65b05d2ba102b86307"
+  integrity sha512-RouJRNEcb4Ua+7IZQs6narCy83Ak6f6eJ/O6r8p9KXF02wuZP8EEyL0G/JuINTMXRCoLqb0QzsVcSi6h6j1UXg==
   dependencies:
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/kv-store" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/kv-store" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-4.2.0-nightly.20260414.tgz#8a775fe9ada3fef47a31362dab7dd3d4d5354953"
-  integrity sha512-8wyhC74W0q7XA872y29gchsmIgICMjoisQMqr/MtzRHPl5yIRoKfuIAF+xyVZef/X/upJNrBMl8n5GIiNo+xrw==
+"@aztec/native@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-4.2.0-rc.1.tgz#7facb176c26ff1c927207516b20d8b6f72f4160d"
+  integrity sha512-4i5zYLpvBYIyaA5Er1G7VQxF3qLstneedPtp+QN46rJHfSqe+KwCkoRGtCQU3lAVOJTvpUXqtQb5HDluUuEb4g==
   dependencies:
-    "@aztec/bb.js" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/bb.js" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-4.2.0-nightly.20260414.tgz#f36f047ce44db376c9ef67777e9a7a5d49c2f79d"
-  integrity sha512-45wpj/GoNTouw8j+Zrm4F6QhnoxnPVvI6/akI8uYxC+IJMTq69suXA4+ONr73pe27tB869T2aTcGY3pi7FE8lw==
+"@aztec/noir-acvm_js@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-4.2.0-rc.1.tgz#4b9ac2a939f8fd2825b51c864264819aaccee8ef"
+  integrity sha512-7ZgzDjMuFFCHLC78iZDEzP8GD76PqHoNo3/CqrJMP/XzLm1QSIKdb0crB+yY5YA5+t3/l5FMy80as+buDcVfWw==
 
-"@aztec/noir-contracts.js@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-4.2.0-nightly.20260414.tgz#c6858665c6af853b5528d6527622482c057ee48c"
-  integrity sha512-L+K4QPJ3xCBnkdl6Oe1XPwdyuYZ0T5Io94RyQWE81Z9vZM9LjUI3hhE6/ZzDSln+4Q718gX+6M7MYc9yKdn3JQ==
+"@aztec/noir-contracts.js@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-4.2.0-rc.1.tgz#20f59681911e6ea615f2c5ddbd4653bdc8bd1d29"
+  integrity sha512-iO0vcHh2RwBdsePN6Y0DTJyf2dvnTuLQ7QgrNCC/+4KrlKr9xtbkQRS7lXP2iXxQP1T3c7Yy1TrINcHmvKVZCg==
   dependencies:
-    "@aztec/aztec.js" "4.2.0-nightly.20260414"
+    "@aztec/aztec.js" "4.2.0-rc.1"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-4.2.0-nightly.20260414.tgz#6d469a1b4e84576cc81b8f590a80012db5360de5"
-  integrity sha512-T/Pznn+bjmhIkg4SY6jmGoco25l8mJH+YQQHjNU0ju3zr0VglPGuHsS6gvh8Z6TAgeJePKzVnps+PeoWlcYISg==
+"@aztec/noir-noir_codegen@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-4.2.0-rc.1.tgz#325513fbc4ef8bf29a1e75eccffe95f564bfe5e1"
+  integrity sha512-C4gO9CL0d2Zba/pewEAJh+J5vCmfTe6ZqsSZEWVUuc96ROn1a584EPxmflz6OhwbY2rTFLzK4D6NXJUjL8Zixg==
   dependencies:
-    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    "@aztec/noir-types" "4.2.0-rc.1"
     glob "^13.0.6"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-4.2.0-nightly.20260414.tgz#7b35031bd580aef9ff38bacc845b6319f29674f7"
-  integrity sha512-0N95PnVbTSqaVI6EWU8lxfSyJdd3CZBEPwPtp3RfmwmbPe4pI6mC4zUgoRjFWfWINA5LFO3wQ+PH2lT0mNxCEA==
+"@aztec/noir-noirc_abi@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-4.2.0-rc.1.tgz#0c73433d60b517662a4f37177d269a6312b08ad2"
+  integrity sha512-AtsRmE4typ3bG56crywfWz0WZ7AMQoJ0Ew2upWe3R4BBgRl9ccfSjrJZJAKMNqiV1hQRgFOQRaxPMgL3Sv+S6w==
   dependencies:
-    "@aztec/noir-types" "4.2.0-nightly.20260414"
+    "@aztec/noir-types" "4.2.0-rc.1"
 
-"@aztec/noir-protocol-circuits-types@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-4.2.0-nightly.20260414.tgz#16bae9af81d9e376e15602c45100ed93e7ef38a0"
-  integrity sha512-pk8C+C8/2AWAoSvN5VUfR1r+poTuQSyaeD8amMqiL7c6r6+Z5APUkJ+QjuGPId04xgXfMLlYq1cKbyEXisPaWw==
+"@aztec/noir-protocol-circuits-types@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-4.2.0-rc.1.tgz#b29649defcb3d442953243504f533da5ed767a0d"
+  integrity sha512-r1iH/bbPXd1Z9g4+gMauRDZxmWXiZJgl93LEMaqIGchvlz2QPGqpUWd99fNMIPmjm4EEShkCb387w6+aqfT2iA==
   dependencies:
-    "@aztec/blob-lib" "4.2.0-nightly.20260414"
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/noir-acvm_js" "4.2.0-nightly.20260414"
-    "@aztec/noir-noir_codegen" "4.2.0-nightly.20260414"
-    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
-    "@aztec/noir-types" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/blob-lib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/noir-acvm_js" "4.2.0-rc.1"
+    "@aztec/noir-noir_codegen" "4.2.0-rc.1"
+    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
+    "@aztec/noir-types" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-4.2.0-nightly.20260414.tgz#bacbd041d9eaa9ced483bfa9c0833411251ac3a2"
-  integrity sha512-jmemYutCgdatPkvDBnPat4AyQsmcB6YVRpjDawufcRWI71a9FICvTVKKZ6UyZJ+35wsDUJucMpwph0Fczxo26g==
+"@aztec/noir-types@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-4.2.0-rc.1.tgz#49ead4bf20f65f57c4c30e1d030b30ce4dfe6d12"
+  integrity sha512-xrSGIbtLUfutxhixd2UFS+AW0K6RDxJfvIF5WGN4DS9KPh+j/F7oJYee/heUvBpj6D7LvxkZZL2T7s/k1xutsA==
 
-"@aztec/protocol-contracts@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-4.2.0-nightly.20260414.tgz#71df734a9c8ceb1e66fd23518a70b986cacaff9e"
-  integrity sha512-mDWUL09FpUdP2ndc6YZBqlOrthKdcxcGaeZg+5NRcx3x4SVGRMEdFlL+EhCDlfV/Rt9W81iKqHqEB6fFUo8a3A==
+"@aztec/protocol-contracts@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-4.2.0-rc.1.tgz#a5d0c29b3631ea410cee11f56044b8cea28ac72a"
+  integrity sha512-VOMuRioeSF8GxrtxZB6ZV9pVbOd1MI9l/2EvyUrT9iX8lXwv1m1p/jAexC/z/FoeikIaWXVNBdAN8Vg66ENiNA==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-4.2.0-nightly.20260414.tgz#1cc88da781f3eeac3d34b7ee75e25acf07b3fed9"
-  integrity sha512-7kgWXgcqjFooxSF0+q5hArek550PX0n3BfJrtq6K1d2QS//cLlmhXg8SaWhWXz6DGi3+7HfkGOhp9A0GcNf5GA==
+"@aztec/pxe@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-4.2.0-rc.1.tgz#2da9fd41542e0bb98093a15e07e6d38793f0cb08"
+  integrity sha512-6UvDqsRMyBdVnQTOaMyrUmDAeDP/cUAhphRIM/Wl4VFKNpxCPf5GyIQ6i+sOxiiIjFg8eYpVys+iQMhVGrdgjQ==
   dependencies:
-    "@aztec/bb-prover" "4.2.0-nightly.20260414"
-    "@aztec/bb.js" "4.2.0-nightly.20260414"
-    "@aztec/builder" "4.2.0-nightly.20260414"
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/ethereum" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/key-store" "4.2.0-nightly.20260414"
-    "@aztec/kv-store" "4.2.0-nightly.20260414"
-    "@aztec/noir-protocol-circuits-types" "4.2.0-nightly.20260414"
-    "@aztec/noir-types" "4.2.0-nightly.20260414"
-    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
-    "@aztec/simulator" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/bb-prover" "4.2.0-rc.1"
+    "@aztec/bb.js" "4.2.0-rc.1"
+    "@aztec/builder" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/ethereum" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/key-store" "4.2.0-rc.1"
+    "@aztec/kv-store" "4.2.0-rc.1"
+    "@aztec/noir-protocol-circuits-types" "4.2.0-rc.1"
+    "@aztec/noir-types" "4.2.0-rc.1"
+    "@aztec/protocol-contracts" "4.2.0-rc.1"
+    "@aztec/simulator" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
@@ -922,40 +922,40 @@
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-4.2.0-nightly.20260414.tgz#4a7262229f1d18fe0cac1357969516a27abbfaa2"
-  integrity sha512-LWsoPiI0sL7BIqKKsr7OJb2pqFq7d+i3y/CTyfrZbiwLgz3/bo6vefF8K/ge1E4UMg2hy8MFLB80cX3k9GEtMA==
+"@aztec/simulator@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-4.2.0-rc.1.tgz#6cdc2305b9e0517c1a5c3a95a55ba7cb349f44a0"
+  integrity sha512-b6uAo9EW7bgyi6HU3yqxzReHLyxZqoWr+y4BdDwWM3Z9b7UjgXzjajZ4HttFd+T8yEfJzgc8Vt54hUl5pXoWpg==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/native" "4.2.0-nightly.20260414"
-    "@aztec/noir-acvm_js" "4.2.0-nightly.20260414"
-    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
-    "@aztec/noir-protocol-circuits-types" "4.2.0-nightly.20260414"
-    "@aztec/noir-types" "4.2.0-nightly.20260414"
-    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
-    "@aztec/telemetry-client" "4.2.0-nightly.20260414"
-    "@aztec/world-state" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/native" "4.2.0-rc.1"
+    "@aztec/noir-acvm_js" "4.2.0-rc.1"
+    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
+    "@aztec/noir-protocol-circuits-types" "4.2.0-rc.1"
+    "@aztec/noir-types" "4.2.0-rc.1"
+    "@aztec/protocol-contracts" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/telemetry-client" "4.2.0-rc.1"
+    "@aztec/world-state" "4.2.0-rc.1"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-4.2.0-nightly.20260414.tgz#9391104518e964d20fa8005551aa03f9b68447a0"
-  integrity sha512-jmhkgiwW3bQibdR6Isk8hK/MfQ30CjSNGPsiYNKK2E87LIAUg6Eq2EkGZsMfIaAfQZjTUxXUns37OkXYeiriLw==
+"@aztec/stdlib@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-4.2.0-rc.1.tgz#709d95e303d54f3969e384e421a71b9cb2bc57b3"
+  integrity sha512-oYnh14hbV1DGL7hor5IFE7GKi1F1DhABc0eKGxskmi9bSPS3/A8EKmiLkF0+uLlCQa+1TLJoZ1z1SG0zlZNnNA==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "4.2.0-nightly.20260414"
-    "@aztec/blob-lib" "4.2.0-nightly.20260414"
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/ethereum" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/l1-artifacts" "4.2.0-nightly.20260414"
-    "@aztec/noir-noirc_abi" "4.2.0-nightly.20260414"
-    "@aztec/validator-ha-signer" "4.2.0-nightly.20260414"
+    "@aztec/bb.js" "4.2.0-rc.1"
+    "@aztec/blob-lib" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/ethereum" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/l1-artifacts" "4.2.0-rc.1"
+    "@aztec/noir-noirc_abi" "4.2.0-rc.1"
+    "@aztec/validator-ha-signer" "4.2.0-rc.1"
     "@google-cloud/storage" "^7.15.0"
     axios "^1.13.5"
     json-stringify-deterministic "1.0.12"
@@ -969,13 +969,13 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-4.2.0-nightly.20260414.tgz#4e0f634c5a26b976457a0c7968bafe757d382719"
-  integrity sha512-1dqezUnuewv3LgRjgWaFIDqtf8pFvTsWp1Dps0JtaF+/y1ty4bS9C5Obqdki4UdeqIaZoiIghm6dEjYl2VyqlQ==
+"@aztec/telemetry-client@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-4.2.0-rc.1.tgz#f0d1498161df774cbe29e54aea470951d847741b"
+  integrity sha512-wlzdrPk+z7FtxEcn8IwneQpz6UUsr8NKGDPjaWo+OTvzk+v75b6Kb7Aijq+IZTlNUkeC/T3FH7rEyan1VJM4WQ==
   dependencies:
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -993,58 +993,58 @@
     prom-client "^15.1.3"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/validator-ha-signer@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/validator-ha-signer/-/validator-ha-signer-4.2.0-nightly.20260414.tgz#74034448580ef191707f5496f253e744ef5761ac"
-  integrity sha512-VT0XeD8Xr2030IR1fRvrQ+duWHNODh4YEWDqwkwbwpceRC88Ib5OyONP43Z4rj7D4sNokNkQJz44pf3qGaO3gw==
+"@aztec/validator-ha-signer@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/validator-ha-signer/-/validator-ha-signer-4.2.0-rc.1.tgz#29455bc3ed92c8cba8781c05497bcf4c558c9588"
+  integrity sha512-+/gyPwi3If/6+/HEM/QbVap9FCqiW4y8whTpZqr8T34bRe00kKZpukLjSmmqMJ7HTMzheSJIyXidTJ2yQEKuWA==
   dependencies:
-    "@aztec/ethereum" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
+    "@aztec/ethereum" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
     node-pg-migrate "^8.0.4"
     pg "^8.11.3"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/wallet-sdk@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-4.2.0-nightly.20260414.tgz#3bd88d3ff66a1a4a1c83afef5566cff7ad11061f"
-  integrity sha512-g4ARmko/g9I6qyTiQZ7YcTG5v3w66OdpUbgQBDYM9xvUHueAZ6A1kAFZ7DmO5lJeYWv9CANzzllOX3AlEKvfxQ==
+"@aztec/wallet-sdk@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-4.2.0-rc.1.tgz#dd7681c3201e0d733c6b5b51a5eb2693211cafbb"
+  integrity sha512-ryz27f1p/EjKYpbXyOO+FQ/yHF9EAxuEz0GZF4r4wdUhl4foFCuZrPcC7NSTSvY7pdBhEqorfUboOkuZrC/3Yg==
   dependencies:
-    "@aztec/aztec.js" "4.2.0-nightly.20260414"
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/entrypoints" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/pxe" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
+    "@aztec/aztec.js" "4.2.0-rc.1"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/entrypoints" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/pxe" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
 
-"@aztec/wallets@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/wallets/-/wallets-4.2.0-nightly.20260414.tgz#a54d74ada81480add7e32ed38a5d418cc29555e0"
-  integrity sha512-lyagiFEg1o+zN4705eQzwe/GjsOC6eV28pV4LIKgGlTxY7mp7l2mYL7Xt6CmStY1pnpMiUxCobKXWHGsuwhT/Q==
+"@aztec/wallets@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/wallets/-/wallets-4.2.0-rc.1.tgz#40874fa4362a1a7f5d1670aafe4afd6af410e0d5"
+  integrity sha512-EtovGV8vpaAcds4Mm/0XdJ4hL32cKRnQpwr3xMIlwNbtJpp/I6daWiexPAvjhIlzlYT7EB5/INYf/FRDRBZMaw==
   dependencies:
-    "@aztec/accounts" "4.2.0-nightly.20260414"
-    "@aztec/aztec.js" "4.2.0-nightly.20260414"
-    "@aztec/entrypoints" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/kv-store" "4.2.0-nightly.20260414"
-    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
-    "@aztec/pxe" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
-    "@aztec/wallet-sdk" "4.2.0-nightly.20260414"
+    "@aztec/accounts" "4.2.0-rc.1"
+    "@aztec/aztec.js" "4.2.0-rc.1"
+    "@aztec/entrypoints" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/kv-store" "4.2.0-rc.1"
+    "@aztec/protocol-contracts" "4.2.0-rc.1"
+    "@aztec/pxe" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/wallet-sdk" "4.2.0-rc.1"
 
-"@aztec/world-state@4.2.0-nightly.20260414":
-  version "4.2.0-nightly.20260414"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-4.2.0-nightly.20260414.tgz#9a3f870e22a52f3e4095cdf72a045858160d84c5"
-  integrity sha512-7xpFo9/YirAez9cRO7FMcLVMGAtYb7Z3TzvzE6lgqdZsetrP1agimPqtDS3gtLYNa8pjdg7jHiy2Vq9Tq4TQdQ==
+"@aztec/world-state@4.2.0-rc.1":
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-4.2.0-rc.1.tgz#bb3503300f732a7106f59d93642efc5136335110"
+  integrity sha512-hgTnqXdIdwehlZQK0cfe6/cDpdQIxtWUjibyw9SBY2hQd11WwLRpSGRBXUhXtb2ioHB18uBfzUspVZetyl2FBQ==
   dependencies:
-    "@aztec/constants" "4.2.0-nightly.20260414"
-    "@aztec/foundation" "4.2.0-nightly.20260414"
-    "@aztec/kv-store" "4.2.0-nightly.20260414"
-    "@aztec/merkle-tree" "4.2.0-nightly.20260414"
-    "@aztec/native" "4.2.0-nightly.20260414"
-    "@aztec/protocol-contracts" "4.2.0-nightly.20260414"
-    "@aztec/stdlib" "4.2.0-nightly.20260414"
-    "@aztec/telemetry-client" "4.2.0-nightly.20260414"
+    "@aztec/constants" "4.2.0-rc.1"
+    "@aztec/foundation" "4.2.0-rc.1"
+    "@aztec/kv-store" "4.2.0-rc.1"
+    "@aztec/merkle-tree" "4.2.0-rc.1"
+    "@aztec/native" "4.2.0-rc.1"
+    "@aztec/protocol-contracts" "4.2.0-rc.1"
+    "@aztec/stdlib" "4.2.0-rc.1"
+    "@aztec/telemetry-client" "4.2.0-rc.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 
@@ -1258,14 +1258,14 @@
     "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.10.0"
     "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.10.0"
 
-"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-c922ff4/defi-wonderland-aztec-benchmark-4.2.0-nightly.20260414-prerelease.c922ff4.tgz":
-  version "4.2.0-nightly.20260414-prerelease.c922ff4"
-  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-c922ff4/defi-wonderland-aztec-benchmark-4.2.0-nightly.20260414-prerelease.c922ff4.tgz#7fba2bf548d976f04c54b478296085b08d50bcc8"
+"@defi-wonderland/aztec-benchmark@https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-49f460a/defi-wonderland-aztec-benchmark-4.2.0-rc.1-prerelease.49f460a.tgz":
+  version "4.2.0-rc.1-prerelease.49f460a"
+  resolved "https://github.com/defi-wonderland/aztec-benchmark/releases/download/prerelease-49f460a/defi-wonderland-aztec-benchmark-4.2.0-rc.1-prerelease.49f460a.tgz#b238164eb4526269d856fbea1da2373511156b2f"
   dependencies:
     "@actions/core" "1.10.1"
     "@actions/exec" "1.1.1"
-    "@aztec/aztec.js" "4.2.0-nightly.20260414"
-    "@aztec/wallets" "4.2.0-nightly.20260414"
+    "@aztec/aztec.js" "4.2.0-rc.1"
+    "@aztec/wallets" "4.2.0-rc.1"
     "@iarna/toml" "2.2.5"
     "@types/node" "22.15.3"
     commander "13.1.0"


### PR DESCRIPTION
Upgrades aztec to 4.2.0 (final release). Base commit identical to 4.2.0-rc.1 (`f8c89cf4`); version strings only.