### PR TITLE
test: ci cache probe (identical to #132)

### DIFF
--- a/src/ts/counter.test.ts
+++ b/src/ts/counter.test.ts
@@ -52,6 +52,6 @@ describe("Counter Contract", () => {
           from: alice,
         })
       ).result,
-    ).toBe(1n);
+    ).toBe(999n);
   });
 });


### PR DESCRIPTION
Identical tree to #132 on a fresh branch — probing whether Actions/AdvSec suppression is keyed on the head sha or on the branch.